### PR TITLE
Add ClioAuthClient with build_authorize_url, exchange_code, and refresh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ target-version = "py313"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+
+[dependency-groups]
+dev = [
+    "respx>=0.23.1",
+]

--- a/src/clio_mcp/auth/client.py
+++ b/src/clio_mcp/auth/client.py
@@ -1,0 +1,83 @@
+"""Async OAuth2 client for Clio token operations."""
+
+from __future__ import annotations
+
+import urllib.parse
+
+import httpx
+
+from clio_mcp.auth.exceptions import ClioTokenRefreshError
+from clio_mcp.auth.models import ClioConfig, ClioTokens
+
+
+class ClioAuthClient:
+    """Handles the HTTP protocol side of Clio OAuth2.
+
+    Builds authorize URLs, exchanges authorization codes for tokens,
+    and refreshes access tokens. Does NOT touch the filesystem —
+    persistence is the token store's job.
+    """
+
+    def __init__(self, config: ClioConfig) -> None:
+        self.config = config
+
+    def build_authorize_url(self, state: str) -> str:
+        """Return the full authorization URL for the user to visit."""
+        params = urllib.parse.urlencode(
+            {
+                "response_type": "code",
+                "client_id": self.config.client_id,
+                "redirect_uri": self.config.redirect_uri,
+                "state": state,
+            }
+        )
+        return f"{self.config.oauth_base}/oauth/authorize?{params}"
+
+    async def exchange_code(self, code: str) -> ClioTokens:
+        """Exchange an authorization code for tokens.
+
+        Raises ClioTokenRefreshError on non-2xx responses.
+        """
+        data = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "client_id": self.config.client_id,
+            "client_secret": self.config.client_secret.get_secret_value(),
+            "redirect_uri": self.config.redirect_uri,
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{self.config.oauth_base}/oauth/token",
+                data=data,
+            )
+
+        if not response.is_success:
+            raise ClioTokenRefreshError(
+                f"Token exchange failed ({response.status_code}): {response.text}"
+            )
+
+        return ClioTokens.from_token_response(response.json())
+
+    async def refresh(self, tokens: ClioTokens) -> ClioTokens:
+        """Refresh an access token using the refresh token.
+
+        Raises ClioTokenRefreshError on non-2xx responses.
+        """
+        data = {
+            "grant_type": "refresh_token",
+            "refresh_token": tokens.refresh_token,
+            "client_id": self.config.client_id,
+            "client_secret": self.config.client_secret.get_secret_value(),
+        }
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.post(
+                f"{self.config.oauth_base}/oauth/token",
+                data=data,
+            )
+
+        if not response.is_success:
+            raise ClioTokenRefreshError(
+                f"Token refresh failed ({response.status_code}): {response.text}"
+            )
+
+        return ClioTokens.from_token_response(response.json(), previous=tokens)

--- a/tests/auth/test_client.py
+++ b/tests/auth/test_client.py
@@ -1,0 +1,182 @@
+"""Tests for ClioAuthClient OAuth2 operations."""
+
+from __future__ import annotations
+
+import urllib.parse
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+import respx
+
+from clio_mcp.auth.client import ClioAuthClient
+from clio_mcp.auth.exceptions import ClioTokenRefreshError
+from clio_mcp.auth.models import ClioConfig, ClioTokens
+
+
+@pytest.fixture
+def config() -> ClioConfig:
+    return ClioConfig(
+        client_id="test-client-id",
+        client_secret="test-client-secret",
+        redirect_uri="http://localhost:8080/callback",
+        api_base="https://app.clio.com/api/v4",
+    )
+
+
+@pytest.fixture
+def auth_client(config: ClioConfig) -> ClioAuthClient:
+    return ClioAuthClient(config)
+
+
+@pytest.fixture
+def token_response() -> dict:
+    return {
+        "access_token": "new-access-token",
+        "refresh_token": "new-refresh-token",
+        "token_type": "bearer",
+        "expires_in": 3600,
+    }
+
+
+@pytest.fixture
+def existing_tokens() -> ClioTokens:
+    return ClioTokens(
+        access_token="old-access-token",
+        refresh_token="old-refresh-token",
+        token_type="bearer",
+        expires_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+class TestBuildAuthorizeUrl:
+    def test_contains_required_params(self, auth_client: ClioAuthClient) -> None:
+        url = auth_client.build_authorize_url(state="abc123")
+        parsed = urllib.parse.urlparse(url)
+        params = urllib.parse.parse_qs(parsed.query)
+
+        assert params["response_type"] == ["code"]
+        assert params["client_id"] == ["test-client-id"]
+        assert params["redirect_uri"] == ["http://localhost:8080/callback"]
+        assert params["state"] == ["abc123"]
+
+    def test_encodes_special_characters_in_state(
+        self, auth_client: ClioAuthClient
+    ) -> None:
+        url = auth_client.build_authorize_url(state="foo=bar&baz")
+        assert "foo%3Dbar%26baz" in url
+        parsed = urllib.parse.urlparse(url)
+        params = urllib.parse.parse_qs(parsed.query)
+        assert params["state"] == ["foo=bar&baz"]
+
+
+class TestExchangeCode:
+    @respx.mock
+    async def test_sends_correct_form_body(
+        self, auth_client: ClioAuthClient, token_response: dict
+    ) -> None:
+        route = respx.post("https://app.clio.com/oauth/token").mock(
+            return_value=httpx.Response(200, json=token_response)
+        )
+
+        await auth_client.exchange_code("auth-code-123")
+
+        request = route.calls[0].request
+        body = urllib.parse.parse_qs(request.content.decode())
+        assert body["grant_type"] == ["authorization_code"]
+        assert body["code"] == ["auth-code-123"]
+        assert body["client_id"] == ["test-client-id"]
+        assert body["client_secret"] == ["test-client-secret"]
+        assert body["redirect_uri"] == ["http://localhost:8080/callback"]
+
+    @respx.mock
+    async def test_returns_tokens_on_success(
+        self, auth_client: ClioAuthClient, token_response: dict
+    ) -> None:
+        respx.post("https://app.clio.com/oauth/token").mock(
+            return_value=httpx.Response(200, json=token_response)
+        )
+
+        tokens = await auth_client.exchange_code("auth-code-123")
+
+        assert tokens.access_token == "new-access-token"
+        assert tokens.refresh_token == "new-refresh-token"
+
+    @respx.mock
+    async def test_raises_on_400_response(
+        self, auth_client: ClioAuthClient
+    ) -> None:
+        respx.post("https://app.clio.com/oauth/token").mock(
+            return_value=httpx.Response(400, text="invalid_grant")
+        )
+
+        with pytest.raises(ClioTokenRefreshError, match="invalid_grant"):
+            await auth_client.exchange_code("bad-code")
+
+
+class TestRefresh:
+    @respx.mock
+    async def test_sends_correct_form_body(
+        self,
+        auth_client: ClioAuthClient,
+        existing_tokens: ClioTokens,
+        token_response: dict,
+    ) -> None:
+        route = respx.post("https://app.clio.com/oauth/token").mock(
+            return_value=httpx.Response(200, json=token_response)
+        )
+
+        await auth_client.refresh(existing_tokens)
+
+        request = route.calls[0].request
+        body = urllib.parse.parse_qs(request.content.decode())
+        assert body["grant_type"] == ["refresh_token"]
+        assert body["refresh_token"] == ["old-refresh-token"]
+        assert body["client_id"] == ["test-client-id"]
+        assert body["client_secret"] == ["test-client-secret"]
+
+    @respx.mock
+    async def test_returns_new_tokens_with_new_refresh_token(
+        self,
+        auth_client: ClioAuthClient,
+        existing_tokens: ClioTokens,
+        token_response: dict,
+    ) -> None:
+        respx.post("https://app.clio.com/oauth/token").mock(
+            return_value=httpx.Response(200, json=token_response)
+        )
+
+        tokens = await auth_client.refresh(existing_tokens)
+
+        assert tokens.access_token == "new-access-token"
+        assert tokens.refresh_token == "new-refresh-token"
+
+    @respx.mock
+    async def test_falls_back_to_previous_refresh_token(
+        self, auth_client: ClioAuthClient, existing_tokens: ClioTokens
+    ) -> None:
+        """Regression test: when Clio omits refresh_token, use previous."""
+        response_without_refresh = {
+            "access_token": "refreshed-access-token",
+            "token_type": "bearer",
+            "expires_in": 3600,
+        }
+        respx.post("https://app.clio.com/oauth/token").mock(
+            return_value=httpx.Response(200, json=response_without_refresh)
+        )
+
+        tokens = await auth_client.refresh(existing_tokens)
+
+        assert tokens.access_token == "refreshed-access-token"
+        assert tokens.refresh_token == "old-refresh-token"
+
+    @respx.mock
+    async def test_raises_on_401_response(
+        self, auth_client: ClioAuthClient, existing_tokens: ClioTokens
+    ) -> None:
+        respx.post("https://app.clio.com/oauth/token").mock(
+            return_value=httpx.Response(401, text="unauthorized")
+        )
+
+        with pytest.raises(ClioTokenRefreshError, match="401"):
+            await auth_client.refresh(existing_tokens)

--- a/uv.lock
+++ b/uv.lock
@@ -199,6 +199,11 @@ eval = [
     { name = "pyyaml" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "respx" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "anthropic", marker = "extra == 'eval'" },
@@ -213,6 +218,9 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev", "eval"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "respx", specifier = ">=0.23.1" }]
 
 [[package]]
 name = "colorama"
@@ -1017,6 +1025,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements the async OAuth2 HTTP client for Clio token operations:
- build_authorize_url(state): constructs the OAuth authorize URL with
  proper query-string encoding via urllib.parse.urlencode
- exchange_code(code): POSTs authorization code to /oauth/token, returns
  ClioTokens on success, raises ClioTokenRefreshError on failure
- refresh(tokens): POSTs refresh_token grant, passes previous=tokens to
  ClioTokens.from_token_response to guard against the ETL bug where
  Clio omits refresh_token from the response

Adds httpx as runtime dep (already present) and respx as dev dep for
mocking httpx in tests. Test suite includes a dedicated regression test
verifying refresh_token fallback to previous value when omitted.

## Testing
9 new tests, 30 total across the auth module. All passing.

## What's next
Bootstrap CLI that ties the module together.
