### PR TITLE
Add bootstrap CLI, get_access_token, and public auth module interface

### DIFF
--- a/src/clio_mcp/auth/__init__.py
+++ b/src/clio_mcp/auth/__init__.py
@@ -1,0 +1,60 @@
+"""Clio OAuth2 authentication module.
+
+Public interface:
+    get_access_token() — the single function tool handlers call to get a
+    valid access token, refreshing transparently if needed.
+"""
+
+from __future__ import annotations
+
+from clio_mcp.auth.client import ClioAuthClient
+from clio_mcp.auth.exceptions import (
+    ClioAuthError,
+    ClioConfigError,
+    ClioTokenError,
+    ClioTokenFileCorruptError,
+    ClioTokenNotFoundError,
+    ClioTokenRefreshError,
+)
+from clio_mcp.auth.models import ClioConfig, ClioTokens
+from clio_mcp.auth.token_store import FileTokenStore, TokenStore
+
+__all__ = [
+    "ClioAuthClient",
+    "ClioAuthError",
+    "ClioConfig",
+    "ClioConfigError",
+    "ClioTokenError",
+    "ClioTokenFileCorruptError",
+    "ClioTokenNotFoundError",
+    "ClioTokenRefreshError",
+    "ClioTokens",
+    "FileTokenStore",
+    "TokenStore",
+    "get_access_token",
+]
+
+
+async def get_access_token(
+    config: ClioConfig,
+    store: TokenStore,
+    client: ClioAuthClient,
+) -> str:
+    """Return a valid access token, refreshing if expired.
+
+    Raises ClioTokenNotFoundError if no tokens are stored (user must run
+    the bootstrap CLI first). Propagates ClioTokenRefreshError if the
+    refresh call fails.
+    """
+    tokens = store.load()
+
+    if tokens is None:
+        raise ClioTokenNotFoundError(
+            "No stored tokens found. Run `python -m clio_mcp.auth` to authorize."
+        )
+
+    if tokens.is_expired():
+        tokens = await client.refresh(tokens)
+        store.save(tokens)
+
+    return tokens.access_token

--- a/src/clio_mcp/auth/__main__.py
+++ b/src/clio_mcp/auth/__main__.py
@@ -1,0 +1,55 @@
+"""CLI entry point: python -m clio_mcp.auth
+
+Runs the OAuth2 bootstrap flow to obtain and store tokens.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+
+from clio_mcp.auth.bootstrap import bootstrap
+from clio_mcp.auth.client import ClioAuthClient
+from clio_mcp.auth.exceptions import ClioAuthError
+from clio_mcp.auth.models import ClioConfig
+from clio_mcp.auth.token_store import FileTokenStore
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Authorize Clio MCP server via OAuth2 browser flow."
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8765,
+        help="Local port for the OAuth callback server (default: 8765)",
+    )
+    args = parser.parse_args()
+
+    try:
+        config = ClioConfig.from_env()
+    except ClioAuthError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        print(
+            "Hint: create a .env file with CLIO_CLIENT_ID, "
+            "CLIO_CLIENT_SECRET, and CLIO_REDIRECT_URI.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    store = FileTokenStore()
+    client = ClioAuthClient(config)
+
+    try:
+        asyncio.run(bootstrap(config, store, client, port=args.port))
+    except ClioAuthError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Authorization successful! Tokens saved to {store.path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/clio_mcp/auth/bootstrap.py
+++ b/src/clio_mcp/auth/bootstrap.py
@@ -1,0 +1,117 @@
+"""OAuth2 bootstrap flow: opens browser, captures callback, exchanges code."""
+
+from __future__ import annotations
+
+import secrets
+import threading
+import webbrowser
+from functools import partial
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.parse import parse_qs, urlparse
+
+from clio_mcp.auth.client import ClioAuthClient
+from clio_mcp.auth.exceptions import ClioAuthError
+from clio_mcp.auth.models import ClioConfig, ClioTokens
+from clio_mcp.auth.token_store import TokenStore
+
+_SUCCESS_HTML = """\
+<!DOCTYPE html>
+<html>
+<head><title>Clio MCP — Authorized</title></head>
+<body>
+<h1>Authorization successful!</h1>
+<p>You can close this tab and return to your terminal.</p>
+</body>
+</html>
+"""
+
+
+class _CallbackHandler(BaseHTTPRequestHandler):
+    """One-shot HTTP handler that captures the OAuth callback."""
+
+    def do_GET(self) -> None:  # noqa: N802
+        qs = parse_qs(urlparse(self.path).query)
+        code = qs.get("code", [None])[0]  # type: ignore[list-item]
+        state = qs.get("state", [None])[0]  # type: ignore[list-item]
+
+        self.server.callback_code = code  # type: ignore[attr-defined]
+        self.server.callback_state = state  # type: ignore[attr-defined]
+
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html")
+        self.end_headers()
+        self.wfile.write(_SUCCESS_HTML.encode())
+
+        self.server.callback_event.set()  # type: ignore[attr-defined]
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        # Suppress default stderr logging
+        pass
+
+
+def _run_server(server: HTTPServer, event: threading.Event) -> None:
+    """Serve until the callback event is set."""
+    while not event.is_set():
+        server.handle_request()
+
+
+async def bootstrap(
+    config: ClioConfig,
+    store: TokenStore,
+    client: ClioAuthClient,
+    port: int = 8765,
+    timeout: float = 300.0,
+) -> ClioTokens:
+    """Run the interactive OAuth2 bootstrap flow.
+
+    Opens a browser for the user to authorize, captures the callback on
+    localhost, exchanges the code for tokens, and saves them.
+
+    Raises ClioAuthError on timeout or state mismatch.
+    """
+    state = secrets.token_urlsafe(32)
+    authorize_url = client.build_authorize_url(state)
+
+    event = threading.Event()
+    server = HTTPServer(("127.0.0.1", port), partial(_CallbackHandler))
+    server.callback_code = None  # type: ignore[attr-defined]
+    server.callback_state = None  # type: ignore[attr-defined]
+    server.callback_event = event  # type: ignore[attr-defined]
+
+    server_thread = threading.Thread(
+        target=_run_server, args=(server, event), daemon=True
+    )
+    server_thread.start()
+
+    try:
+        webbrowser.open(authorize_url)
+
+        arrived = event.wait(timeout=timeout)
+        if not arrived:
+            raise ClioAuthError(
+                f"Timed out waiting for OAuth callback after {timeout} seconds. "
+                "Please try again."
+            )
+
+        callback_state = server.callback_state  # type: ignore[attr-defined]
+        callback_code = server.callback_code  # type: ignore[attr-defined]
+
+        if callback_state != state:
+            raise ClioAuthError(
+                "OAuth state mismatch — possible CSRF attack. "
+                "Please try the authorization flow again."
+            )
+
+        if not callback_code:
+            raise ClioAuthError(
+                "No authorization code received in the callback. "
+                "The user may have denied the request."
+            )
+
+        tokens = await client.exchange_code(callback_code)
+        store.save(tokens)
+        return tokens
+
+    finally:
+        server.shutdown()
+        server_thread.join(timeout=5.0)

--- a/tests/auth/test_get_access_token.py
+++ b/tests/auth/test_get_access_token.py
@@ -1,0 +1,105 @@
+"""Tests for the public get_access_token() interface."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+from clio_mcp.auth import get_access_token
+from clio_mcp.auth.exceptions import ClioTokenNotFoundError, ClioTokenRefreshError
+from clio_mcp.auth.models import ClioConfig, ClioTokens
+from clio_mcp.auth.token_store import TokenStore
+
+
+class InMemoryTokenStore(TokenStore):
+    """Simple in-memory token store for testing."""
+
+    def __init__(self, tokens: ClioTokens | None = None) -> None:
+        self.tokens = tokens
+
+    def load(self) -> ClioTokens | None:
+        return self.tokens
+
+    def save(self, tokens: ClioTokens) -> None:
+        self.tokens = tokens
+
+    def clear(self) -> None:
+        self.tokens = None
+
+
+@pytest.fixture
+def config() -> ClioConfig:
+    return ClioConfig(
+        client_id="test-client-id",
+        client_secret="test-client-secret",
+        redirect_uri="http://localhost:8765/callback",
+    )
+
+
+def _make_tokens(*, expired: bool = False) -> ClioTokens:
+    if expired:
+        expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+    else:
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=1)
+    return ClioTokens(
+        access_token="access-123",
+        refresh_token="refresh-456",
+        expires_at=expires_at,
+    )
+
+
+def _make_refreshed_tokens() -> ClioTokens:
+    return ClioTokens(
+        access_token="access-refreshed",
+        refresh_token="refresh-789",
+        expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+    )
+
+
+@pytest.mark.asyncio
+async def test_raises_token_not_found_when_no_tokens(config: ClioConfig) -> None:
+    store = InMemoryTokenStore(tokens=None)
+    client = AsyncMock()
+
+    with pytest.raises(ClioTokenNotFoundError, match="No stored tokens found"):
+        await get_access_token(config, store, client)
+
+
+@pytest.mark.asyncio
+async def test_returns_access_token_when_valid(config: ClioConfig) -> None:
+    tokens = _make_tokens(expired=False)
+    store = InMemoryTokenStore(tokens=tokens)
+    client = AsyncMock()
+
+    result = await get_access_token(config, store, client)
+
+    assert result == "access-123"
+    client.refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refreshes_when_expired(config: ClioConfig) -> None:
+    tokens = _make_tokens(expired=True)
+    refreshed = _make_refreshed_tokens()
+    store = InMemoryTokenStore(tokens=tokens)
+    client = AsyncMock()
+    client.refresh.return_value = refreshed
+
+    result = await get_access_token(config, store, client)
+
+    assert result == "access-refreshed"
+    client.refresh.assert_called_once_with(tokens)
+    assert store.tokens == refreshed
+
+
+@pytest.mark.asyncio
+async def test_propagates_refresh_error(config: ClioConfig) -> None:
+    tokens = _make_tokens(expired=True)
+    store = InMemoryTokenStore(tokens=tokens)
+    client = AsyncMock()
+    client.refresh.side_effect = ClioTokenRefreshError("refresh failed")
+
+    with pytest.raises(ClioTokenRefreshError, match="refresh failed"):
+        await get_access_token(config, store, client)


### PR DESCRIPTION
Complete the auth module with three new files:

- bootstrap.py: interactive OAuth2 flow that opens the user's browser,
  runs a one-shot localhost callback server, verifies the returned state
  parameter to prevent CSRF, exchanges the code for tokens, and saves
  them. Server is always shut down cleanly in a finally block.

- __init__.py: re-exports all public types and defines get_access_token(),
  the single async function tool handlers call. Loads tokens from the
  store, refreshes transparently when expired, and raises
  ClioTokenNotFoundError if no tokens exist yet.

- __main__.py: CLI entry point (python -m clio_mcp.auth) that parses
  --port, loads config from env with a helpful hint on failure, and runs
  the bootstrap coroutine.

The auth module is now feature-complete: models, exceptions, token store,
HTTP client, bootstrap flow, and runtime accessor.
