### PR TITLE
feat: add ClioClient and matters tools

### DIFF
--- a/src/clio_mcp/client.py
+++ b/src/clio_mcp/client.py
@@ -1,0 +1,69 @@
+"""Async HTTP wrapper for Clio's main API."""
+
+from __future__ import annotations
+
+import httpx
+
+from clio_mcp.auth import get_access_token
+from clio_mcp.auth.client import ClioAuthClient
+from clio_mcp.auth.models import ClioConfig
+from clio_mcp.auth.token_store import FileTokenStore, TokenStore
+from clio_mcp.exceptions import ClioAPIError, ClioNotFoundError
+from clio_mcp.models import Matter
+
+
+class ClioClient:
+    """Async HTTP wrapper for Clio's main API.
+
+    Handles auth-header injection, response parsing into typed models,
+    and error mapping. All outbound Clio API calls go through here.
+    """
+
+    def __init__(
+        self,
+        config: ClioConfig,
+        *,
+        token_store: TokenStore | None = None,
+        auth_client: ClioAuthClient | None = None,
+    ) -> None:
+        self.config = config
+        self._token_store = token_store or FileTokenStore()
+        self._auth_client = auth_client or ClioAuthClient(config)
+
+    async def get_matter(self, matter_id: int) -> Matter:
+        url = f"{self.config.api_base}/matters/{matter_id}.json"
+        headers = await self._authorized_headers()
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(url, headers=headers)
+
+        self._raise_for_status(response)
+        return Matter.model_validate(response.json()["data"])
+
+    async def search_matters(self, query: str, limit: int = 25) -> list[Matter]:
+        url = f"{self.config.api_base}/matters.json"
+        headers = await self._authorized_headers()
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(
+                url,
+                headers=headers,
+                params={"query": query, "limit": limit},
+            )
+
+        self._raise_for_status(response)
+        return [Matter.model_validate(item) for item in response.json()["data"]]
+
+    async def _authorized_headers(self) -> dict[str, str]:
+        token = await get_access_token(
+            self.config, self._token_store, self._auth_client
+        )
+        return {"Authorization": f"Bearer {token}"}
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.is_success:
+            return
+        if response.status_code == 404:
+            raise ClioNotFoundError(response.status_code, response.text)
+        raise ClioAPIError(response.status_code, response.text)

--- a/src/clio_mcp/exceptions.py
+++ b/src/clio_mcp/exceptions.py
@@ -1,0 +1,20 @@
+"""Exceptions raised by the Clio main-API client."""
+
+from __future__ import annotations
+
+
+class ClioAPIError(Exception):
+    """Base for all Clio main-API errors. Carries the HTTP status code
+    and response body so callers can inspect what went wrong.
+    """
+
+    def __init__(self, status_code: int, body: str) -> None:
+        self.status_code = status_code
+        self.body = body
+        super().__init__(f"Clio API error ({status_code}): {body}")
+
+
+class ClioNotFoundError(ClioAPIError):
+    """Raised on 404 responses so tools can handle a missing resource
+    (e.g. "matter not found") separately from other API failures.
+    """

--- a/src/clio_mcp/tools/matters.py
+++ b/src/clio_mcp/tools/matters.py
@@ -1,0 +1,36 @@
+"""FastMCP tool functions for Clio matters."""
+
+from __future__ import annotations
+
+from clio_mcp.auth.models import ClioConfig
+from clio_mcp.client import ClioClient
+from clio_mcp.models import Matter
+
+_client: ClioClient | None = None
+
+
+def _get_client() -> ClioClient:
+    global _client
+    if _client is None:
+        _client = ClioClient(ClioConfig.from_env())
+    return _client
+
+
+async def get_matter(matter_id: int) -> Matter:
+    """Look up a specific matter by its Clio ID. Returns full details
+    including the client, practice area, status, and assigned attorneys.
+    Use this when you have a matter's ID and need its details; use
+    search_matters instead if you're looking for matters by name,
+    client, or keyword.
+    """
+    return await _get_client().get_matter(matter_id)
+
+
+async def search_matters(query: str, limit: int = 25) -> list[Matter]:
+    """Search for matters by keyword. Matches against matter numbers,
+    descriptions, and client names. Returns up to limit matters
+    (default 25, max 100). Use this to find matters when you don't have
+    the specific matter ID — for example "all Smith matters" or
+    "contract disputes".
+    """
+    return await _get_client().search_matters(query, limit)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,113 @@
+"""Tests for ClioClient main-API operations."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import httpx
+import pytest
+import respx
+
+from clio_mcp.auth.models import ClioConfig
+from clio_mcp.client import ClioClient
+from clio_mcp.exceptions import ClioAPIError, ClioNotFoundError
+from clio_mcp.models import Matter
+
+MATTER_PAYLOAD = {
+    "id": 123,
+    "display_number": "00001-Smith",
+    "description": "Contract dispute with ACME Corp",
+    "status": "Open",
+    "client": {"id": 42, "name": "Smith, John"},
+    "practice_area": {"id": 7, "name": "Litigation"},
+}
+
+
+@pytest.fixture
+def config() -> ClioConfig:
+    return ClioConfig(
+        client_id="test-client-id",
+        client_secret="test-client-secret",
+        redirect_uri="http://localhost:8080/callback",
+        api_base="https://app.clio.com/api/v4",
+    )
+
+
+@pytest.fixture
+def client(config: ClioConfig) -> ClioClient:
+    return ClioClient(config)
+
+
+@pytest.fixture(autouse=True)
+def mock_access_token() -> Iterator[None]:
+    """Stub out the token-refresh flow with a fixed bearer token."""
+
+    async def fake_get_access_token(*args: object, **kwargs: object) -> str:
+        return "fake-access-token"
+
+    with patch("clio_mcp.client.get_access_token", side_effect=fake_get_access_token):
+        yield
+
+
+class TestGetMatter:
+    @respx.mock
+    async def test_returns_parsed_matter(self, client: ClioClient) -> None:
+        route = respx.get("https://app.clio.com/api/v4/matters/123.json").mock(
+            return_value=httpx.Response(200, json={"data": MATTER_PAYLOAD})
+        )
+
+        matter = await client.get_matter(123)
+
+        assert isinstance(matter, Matter)
+        assert matter.id == 123
+        assert matter.display_number == "00001-Smith"
+        assert matter.client.name == "Smith, John"
+        assert matter.practice_area.id == 7
+
+        sent_auth = route.calls[0].request.headers["Authorization"]
+        assert sent_auth == "Bearer fake-access-token"
+
+    @respx.mock
+    async def test_raises_not_found_on_404(self, client: ClioClient) -> None:
+        respx.get("https://app.clio.com/api/v4/matters/999.json").mock(
+            return_value=httpx.Response(404, text='{"error":"not found"}')
+        )
+
+        with pytest.raises(ClioNotFoundError) as exc_info:
+            await client.get_matter(999)
+
+        assert exc_info.value.status_code == 404
+        assert "not found" in exc_info.value.body
+
+    @respx.mock
+    async def test_raises_api_error_on_500(self, client: ClioClient) -> None:
+        respx.get("https://app.clio.com/api/v4/matters/1.json").mock(
+            return_value=httpx.Response(500, text="internal error")
+        )
+
+        with pytest.raises(ClioAPIError) as exc_info:
+            await client.get_matter(1)
+
+        assert not isinstance(exc_info.value, ClioNotFoundError)
+        assert exc_info.value.status_code == 500
+        assert exc_info.value.body == "internal error"
+
+
+class TestSearchMatters:
+    @respx.mock
+    async def test_returns_list_of_matters(self, client: ClioClient) -> None:
+        second = {**MATTER_PAYLOAD, "id": 124, "display_number": "00002-Smith"}
+        route = respx.get("https://app.clio.com/api/v4/matters.json").mock(
+            return_value=httpx.Response(200, json={"data": [MATTER_PAYLOAD, second]})
+        )
+
+        matters = await client.search_matters("Smith", limit=10)
+
+        assert len(matters) == 2
+        assert all(isinstance(m, Matter) for m in matters)
+        assert [m.id for m in matters] == [123, 124]
+
+        request = route.calls[0].request
+        assert request.url.params["query"] == "Smith"
+        assert request.url.params["limit"] == "10"

--- a/tests/test_tools/test_matters.py
+++ b/tests/test_tools/test_matters.py
@@ -1,0 +1,41 @@
+"""Tests for the matters tool functions.
+
+These tests verify only the thin delegation layer; HTTP behavior is
+exercised in tests/test_client.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from clio_mcp.models import Matter
+from clio_mcp.tools import matters
+
+
+@pytest.fixture
+def sample_matter() -> Matter:
+    return Matter(id=1, display_number="00001-Smith")
+
+
+async def test_get_matter_delegates_to_client(sample_matter: Matter) -> None:
+    fake_client = AsyncMock()
+    fake_client.get_matter.return_value = sample_matter
+
+    with patch.object(matters, "_get_client", return_value=fake_client):
+        result = await matters.get_matter(1)
+
+    fake_client.get_matter.assert_awaited_once_with(1)
+    assert result is sample_matter
+
+
+async def test_search_matters_delegates_to_client(sample_matter: Matter) -> None:
+    fake_client = AsyncMock()
+    fake_client.search_matters.return_value = [sample_matter]
+
+    with patch.object(matters, "_get_client", return_value=fake_client):
+        result = await matters.search_matters("Smith", limit=10)
+
+    fake_client.search_matters.assert_awaited_once_with("Smith", 10)
+    assert result == [sample_matter]


### PR DESCRIPTION
## Summary

Adds the Clio main-API client and the first two MCP tools for matters.

## Changes

- `src/clio_mcp/client.py` — `ClioClient` class wrapping httpx for Clio's main API. Injects auth headers, parses JSON responses into Pydantic models, maps HTTP errors to typed exceptions.
- `src/clio_mcp/exceptions.py` — `ClioAPIError` base and `ClioNotFoundError` subclass for 404s.
- `src/clio_mcp/tools/matters.py` — `get_matter(matter_id)` and `search_matters(query, limit)` tool functions. Thin delegates to `ClioClient`. Docstrings written for attorney end-users, not developers.
- `tests/test_client.py` — httpx mocked via respx. Covers 200 success, 404 → ClioNotFoundError, 500 → ClioAPIError, and list parsing for search.
- `tests/tools/test_matters.py` — client mocked. Verifies tools delegate correctly.

## Testing

- N new tests, all pass. [fill in count from Claude Code's report]
- Ruff clean.
- Manual smoke test against Day One Law sandbox: deferred to post-merge.

## Deferred

- Pagination on `search_matters` — currently capped at `limit`.
- Retry logic on transient failures.
- OTel instrumentation on outbound requests.
- Server wiring — tools are defined but not yet registered in `server.py`.

## Notes

First substantive feature commits for the matters module. Client and tools are separate commits on the branch for reviewability.