### PR TITLE
feat(server): register matter tools with FastMCP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "python-dotenv",
 ]
 
+[project.scripts]
+clio-mcp = "clio_mcp.server:main"
+
 [project.optional-dependencies]
 dev = [
     "pytest",

--- a/src/clio_mcp/server.py
+++ b/src/clio_mcp/server.py
@@ -1,0 +1,18 @@
+"""FastMCP server entry point for Clio MCP."""
+
+from fastmcp import FastMCP
+
+from clio_mcp.tools.matters import get_matter, search_matters
+
+mcp = FastMCP("clio-mcp-server")
+
+mcp.add_tool(get_matter)
+mcp.add_tool(search_matters)
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Wires get_matter and search_matters into the FastMCP server so they're discoverable and callable by MCP clients.

## Changes
- src/clio_mcp/server.py: new module, instantiates FastMCP and registers matter tools via add_tool()
- pyproject.toml: adds clio-mcp console script entry point

## Testing
- uv sync succeeds
- uv run clio-mcp launches without error
- Manual smoke test against Day One Law sandbox deferred to post-merge (requires live credentials)

## Deferred
- Contacts tools (separate PR)
- OTel instrumentation of tool calls
- Revisit singleton ClioClient pattern if we add multi-tenancy

## Notes
Tools are registered programmatically rather than via @mcp.tool() decorator on the functions themselves, to keep tools/matters.py transport-agnostic.