### PR TITLE
fix(server): load .env at import time so fastmcp dev picks it up

### DIFF
--- a/src/clio_mcp/server.py
+++ b/src/clio_mcp/server.py
@@ -1,9 +1,12 @@
 """FastMCP server entry point for Clio MCP."""
 
 from dotenv import load_dotenv
-from fastmcp import FastMCP
 
-from clio_mcp.tools.matters import get_matter, search_matters
+load_dotenv()
+
+from fastmcp import FastMCP  # noqa: E402
+
+from clio_mcp.tools.matters import get_matter, search_matters  # noqa: E402
 
 mcp = FastMCP("clio-mcp-server")
 
@@ -12,7 +15,6 @@ mcp.add_tool(search_matters)
 
 
 def main() -> None:
-    load_dotenv()
     mcp.run()
 
 


### PR DESCRIPTION
## Summary
Moves load_dotenv() to module scope in server.py so environment variables load when FastMCP imports the server module for `fastmcp dev inspector`. Previously load_dotenv() sat inside main(), which never runs under the dev inspector's import-based launch path.

## Changes
- src/clio_mcp/server.py: load_dotenv() called at module scope instead of inside main()

## Testing
- uv run fastmcp dev inspector src/clio_mcp/server.py (no --env-file flag) connects and lists tools
- search_matters call against sandbox returns expected results
- uv run python -m clio_mcp.auth bootstrap still works (auth/__main__.py unchanged)

## Notes
This is deliberate inconsistency with auth/__main__.py, which keeps load_dotenv() inside main(). The difference: server.py is imported as a library by FastMCP's dev tooling and must be functional at import time. auth/__main__.py is only ever run as a script via `python -m`, so main() always executes.

## Deferred
- Bootstrap shutdown cleanup (separate PR)
- Contacts tools