### PR TITLE
fix(auth): clean bootstrap shutdown and expose --timeout

### DIFF
--- a/src/clio_mcp/auth/__main__.py
+++ b/src/clio_mcp/auth/__main__.py
@@ -29,6 +29,12 @@ def main() -> None:
         default=8765,
         help="Local port for the OAuth callback server (default: 8765)",
     )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=300.0,
+        help="Seconds to wait for the OAuth callback (default: 300)",
+    )
     args = parser.parse_args()
 
     try:
@@ -46,7 +52,9 @@ def main() -> None:
     client = ClioAuthClient(config)
 
     try:
-        asyncio.run(bootstrap(config, store, client, port=args.port))
+        asyncio.run(
+            bootstrap(config, store, client, port=args.port, timeout=args.timeout)
+        )
     except ClioAuthError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/src/clio_mcp/auth/bootstrap.py
+++ b/src/clio_mcp/auth/bootstrap.py
@@ -49,12 +49,6 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         pass
 
 
-def _run_server(server: HTTPServer, event: threading.Event) -> None:
-    """Serve until the callback event is set."""
-    while not event.is_set():
-        server.handle_request()
-
-
 async def bootstrap(
     config: ClioConfig,
     store: TokenStore,
@@ -78,9 +72,7 @@ async def bootstrap(
     server.callback_state = None  # type: ignore[attr-defined]
     server.callback_event = event  # type: ignore[attr-defined]
 
-    server_thread = threading.Thread(
-        target=_run_server, args=(server, event), daemon=True
-    )
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
     server_thread.start()
 
     try:


### PR DESCRIPTION
## Summary
Fixes two issues in the OAuth bootstrap flow: the terminal hangs after a successful authorization because HTTPServer.handle_request() blocks on socket accept that server.shutdown() can't interrupt, and the CLI didn't expose --timeout so 2FA-delayed flows required a source edit to extend the default 300s wait.

## Changes
- src/clio_mcp/auth/bootstrap.py: server thread now runs serve_forever() instead of a handle_request() loop; shutdown() in the finally block now cleanly stops the server
- src/clio_mcp/auth/__main__.py: add --timeout argument, wire through to bootstrap()

## Testing
- Full bootstrap flow completes and terminal returns to prompt within 1–2 seconds of "Authorization successful"
- --timeout flag accepted and passed through
- --help output shows the new flag

## Deferred
- Contacts tools
- Refresh-on-401 in ClioClient

## Notes
The _run_server helper is gone. It was working around the wrong problem — handle_request() in a loop is the pattern you'd use if you wanted fine-grained control over request handling between polls, but we just want "serve until told to stop," which is exactly what serve_forever()/shutdown() provide.