### PR TITLE
docs(tools): tighten search_matters query guidance

### DIFF
--- a/src/clio_mcp/tools/matters.py
+++ b/src/clio_mcp/tools/matters.py
@@ -28,9 +28,14 @@ async def get_matter(matter_id: int) -> Matter:
 
 async def search_matters(query: str, limit: int = 25) -> list[Matter]:
     """Search for matters by keyword. Matches against matter numbers,
-    descriptions, and client names. Returns up to limit matters
-    (default 25, max 100). Use this to find matters when you don't have
-    the specific matter ID — for example "all Smith matters" or
-    "contract disputes".
+    descriptions, and client names.
+
+    Pass distinctive terms — a company name, person's last name. 
+    Do not pass full sentences or predicate expressions.
+
+    Good: "Paxos", "Smith"
+    Bad: "all Smith matters", "client name contains Paxos"
+
+    Returns up to limit matters (default 25, max 100).
     """
     return await _get_client().search_matters(query, limit)


### PR DESCRIPTION
## Summary

Tightens the `search_matters` tool docstring to steer the LLM toward
distinctive single-term queries and away from natural-language
predicates. The docstring is the tool description the model reads on
every tool-selection decision, so this is interface, not documentation.

## Motivation

Yesterday's smoke test surfaced that the previous docstring's
example — `"all Smith matters"` — was encouraging sentence-shaped
queries that don't match how Clio's keyword search actually behaves.
Replacing the example with explicit good/bad pairs should push the
model toward queries Clio can resolve.

## Before

```
Search for matters by keyword. Matches against matter numbers,
descriptions, and client names. Returns up to limit matters
(default 25, max 100). Use this to find matters when you don't have
the specific matter ID — for example "all Smith matters" or
"contract disputes".
```

## After

```
Search for matters by keyword. Matches against matter numbers,
descriptions, and client names.

Pass distinctive terms — a company name, person's last name. 
Do not pass full sentences or predicate expressions.

Good: "Smith"
Bad: "all Smith matters"

Returns up to limit matters (default 25, max 100).
```

## Test plan

- [x] `uv run pytest` — 48/48 passing, no functional change
- [x] Manual inspector verification before merge:
      `uv run fastmcp dev inspector src/clio_mcp/server.py`

## Open question (not a change in this PR)

The phrasing "distinctive terms" (plural) implies multi-word queries
work, but yesterday's smoke test only validated single-token queries
("Smith"). If later evals show that multi-word distinctive queries
degrade recall, we should tighten further — e.g. restrict to a single
term explicitly.

The pattern seems to be "substring match against real field values."