### PR TITLE
fix(matters): enforce documented max-100 limit

### DIFF
--- a/src/clio_mcp/tools/matters.py
+++ b/src/clio_mcp/tools/matters.py
@@ -36,6 +36,9 @@ async def search_matters(query: str, limit: int = 25) -> list[Matter]:
     Good: "Acme", "Smith"
     Bad: "all Smith matters", "client name contains Acme"
 
-    Returns up to limit matters (default 25, max 100).
+    Returns up to limit matters (default 25, max 100). Passing a limit
+    above 100 raises ValueError.
     """
+    if limit > 100:
+        raise ValueError("limit must be 100 or fewer")
     return await _get_client().search_matters(query, limit)

--- a/tests/test_tools/test_matters.py
+++ b/tests/test_tools/test_matters.py
@@ -39,3 +39,8 @@ async def test_search_matters_delegates_to_client(sample_matter: Matter) -> None
 
     fake_client.search_matters.assert_awaited_once_with("Smith", 10)
     assert result == [sample_matter]
+
+
+async def test_search_matters_rejects_limit_above_100() -> None:
+    with pytest.raises(ValueError, match="100"):
+        await matters.search_matters("Smith", limit=101)


### PR DESCRIPTION
## Summary

- Add a `ValueError` guard in `search_matters` when `limit > 100`, mirroring the guard added for `search_contacts` in #11.
- Align the docstring wording with `search_contacts` so both tools state the max the same way.

PR #11's review flagged that the matters tool documented a max of 100 but did not enforce it. Keeping this as a separate PR from the contacts work for scope discipline and a clean history; `search_contacts` already has the equivalent guard from #11.

## Test plan

- [x] `uv run pytest` (60 passed)
- [x] New test `test_search_matters_rejects_limit_above_100` mirrors the contacts equivalent