### PR TITLE
feat(evals): scaffold Anthropic-SDK-as-MCP-client eval harness

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,42 @@
+# Evals
+
+## What this is
+
+An eval harness for the Clio MCP server. The harness launches the server
+as a stdio subprocess, uses the Anthropic SDK to drive Claude with the
+server's tools attached, and observes how Claude selects tools and
+constructs arguments in response to a prompt.
+
+## What "eval" means here
+
+Quantitative measurement of tool selection and argument construction —
+*which* tool the model picks, with *what* arguments, on *which* turn —
+not just "did it produce a reasonable-looking answer." Concrete metrics
+are TBD. This skeleton validates end-to-end plumbing only; metrics,
+scenario libraries, and result storage come in later PRs.
+
+## Running
+
+Run from the repo root (not from `evals/`):
+
+```bash
+uv run --group evals python -m evals.harness
+uv run --group evals python -m evals.harness --query "find contacts named Smith"
+```
+
+Requires `ANTHROPIC_API_KEY` in `.env`. The harness spawns the server
+as a subprocess, which needs authenticated Clio tokens — run
+`uv run python -m clio_mcp.auth` once beforehand if you haven't already.
+The server subprocess inherits the harness's environment, so `CLIO_*`
+vars propagate automatically.
+
+## Architecture
+
+Deliberately a hand-rolled agent loop rather than the Anthropic SDK's
+built-in MCP connector: at each step the harness calls
+`client.messages.create()`, inspects each `tool_use` block in the
+response, invokes the corresponding tool via the MCP `ClientSession`,
+and appends `tool_result` blocks to the conversation. It loops until
+`stop_reason == "end_turn"` (capped at 5 iterations). The explicit loop
+gives per-step visibility — tool name, arguments, result, latency — which
+is what the upcoming metrics layer will hook into.

--- a/evals/harness.py
+++ b/evals/harness.py
@@ -1,0 +1,124 @@
+"""Hand-rolled Anthropic-SDK-as-MCP-client eval harness.
+
+Launches the Clio MCP server as a stdio subprocess, exposes its tools
+to Claude via the Anthropic Messages API, and runs a single scenario
+through an explicit agent loop. Skeleton only — no metrics, no result
+storage, no scenario library yet.
+"""
+
+import argparse
+import asyncio
+import json
+import sys
+
+from anthropic import AsyncAnthropic
+from dotenv import load_dotenv
+from mcp import ClientSession, StdioServerParameters, types
+from mcp.client.stdio import stdio_client
+
+load_dotenv()
+
+MODEL = "claude-sonnet-4-5"
+MAX_TOKENS = 1024
+MAX_ITERATIONS = 5
+DEFAULT_QUERY = "find matters matching 'Acme'"
+
+
+def _mcp_tool_to_anthropic(tool: types.Tool) -> dict:
+    """Convert an MCP tool definition to Anthropic's tool schema shape."""
+    return {
+        "name": tool.name,
+        "description": tool.description or "",
+        "input_schema": tool.inputSchema,
+    }
+
+
+def _format_tool_result(result: types.CallToolResult) -> str:
+    """Flatten an MCP tool result's content blocks into a single string."""
+    parts: list[str] = []
+    for block in result.content:
+        if isinstance(block, types.TextContent):
+            parts.append(block.text)
+        else:
+            parts.append(block.model_dump_json())
+    return "\n".join(parts)
+
+
+async def run_scenario(session: ClientSession, query: str) -> None:
+    tools_response = await session.list_tools()
+    mcp_tools = tools_response.tools
+    print("Available tools:", [t.name for t in mcp_tools])
+
+    anthropic_tools = [_mcp_tool_to_anthropic(t) for t in mcp_tools]
+    client = AsyncAnthropic()
+    messages: list[dict] = [{"role": "user", "content": query}]
+
+    for iteration in range(1, MAX_ITERATIONS + 1):
+        print(f"Iteration {iteration}:")
+        response = await client.messages.create(
+            model=MODEL,
+            max_tokens=MAX_TOKENS,
+            messages=messages,
+            tools=anthropic_tools,
+        )
+
+        tool_results: list[dict] = []
+        for block in response.content:
+            if block.type == "tool_use":
+                print(f"Tool call: {block.name} {json.dumps(block.input)}")
+                result = await session.call_tool(block.name, block.input)
+                result_text = _format_tool_result(result)
+                print(f"Tool result: {result_text}")
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": result_text,
+                        "is_error": result.isError,
+                    }
+                )
+
+        messages.append({"role": "assistant", "content": response.content})
+
+        if response.stop_reason == "end_turn":
+            final_text = "".join(
+                block.text for block in response.content if block.type == "text"
+            )
+            print(f"Final response: {final_text}")
+            return
+
+        if not tool_results:
+            print(
+                f"No tool_use blocks and stop_reason={response.stop_reason!r}; stopping."
+            )
+            return
+
+        messages.append({"role": "user", "content": tool_results})
+
+    print(f"Reached max iterations ({MAX_ITERATIONS}) without end_turn; stopping.")
+
+
+async def main() -> None:
+    parser = argparse.ArgumentParser(description="Clio MCP eval harness skeleton.")
+    parser.add_argument(
+        "--query",
+        default=DEFAULT_QUERY,
+        help=f"User prompt to send to Claude. Default: {DEFAULT_QUERY!r}",
+    )
+    args = parser.parse_args()
+
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "clio_mcp.server"],
+    )
+
+    async with (
+        stdio_client(server_params) as (read, write),
+        ClientSession(read, write) as session,
+    ):
+        await session.initialize()
+        await run_scenario(session, args.query)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,6 @@ dependencies = [
 [project.scripts]
 clio-mcp = "clio_mcp.server:main"
 
-[project.optional-dependencies]
-eval = [
-    "anthropic",
-    "pyyaml",
-]
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -41,6 +35,10 @@ dev = [
     "pytest-asyncio>=1.3.0",
     "respx>=0.23.1",
     "ruff>=0.15.11",
+]
+evals = [
+    "anthropic>=0.96.0",
+    "mcp>=1.27.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -197,12 +197,6 @@ dependencies = [
     { name = "python-dotenv" },
 ]
 
-[package.optional-dependencies]
-eval = [
-    { name = "anthropic" },
-    { name = "pyyaml" },
-]
-
 [package.dev-dependencies]
 dev = [
     { name = "pre-commit" },
@@ -211,18 +205,19 @@ dev = [
     { name = "respx" },
     { name = "ruff" },
 ]
+evals = [
+    { name = "anthropic" },
+    { name = "mcp" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", marker = "extra == 'eval'" },
     { name = "fastmcp" },
     { name = "httpx" },
     { name = "platformdirs", specifier = ">=4.9.6" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "python-dotenv" },
-    { name = "pyyaml", marker = "extra == 'eval'" },
 ]
-provides-extras = ["eval"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -231,6 +226,10 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.15.11" },
+]
+evals = [
+    { name = "anthropic", specifier = ">=0.96.0" },
+    { name = "mcp", specifier = ">=1.27.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

First step of Phase 1 Week 2: end-to-end plumbing for an eval harness that drives the Clio MCP server via the Anthropic SDK. Skeleton only — no metrics, scenarios library, or result storage yet.

- Adds `[dependency-groups].evals` (anthropic, mcp) and removes the now-redundant `[project.optional-dependencies].eval` block (drops unused `pyyaml`; future scenarios PR can re-add if needed).
- Scaffolds `evals/` as a sibling of `src/` and `tests/` with `__init__.py`, a brief portfolio-facing `README.md`, and `harness.py`.
- `harness.py` spawns the server as a stdio subprocess (`python -m clio_mcp.server`), opens a `ClientSession`, converts MCP tool schemas to Anthropic's shape, and runs a hand-rolled agent loop: call Anthropic Messages API → execute each `tool_use` via the MCP session → append `tool_result` blocks → repeat until `end_turn` (hard cap 5 iterations).
- Scenario prompt is parameterized via `--query` with a generic default (`find matters matching 'Acme'`) — no real client or matter names ship in the repo, per CLAUDE.md confidentiality rules.
- Model: `claude-sonnet-4-5`, `max_tokens=1024`. Labeled prints at each step (Available tools, Iteration N, Tool call, Tool result, Final response) for future metrics hooks.
- Deliberately avoids the Anthropic SDK's built-in MCP connector so upcoming PRs can instrument each loop step with latency, tool-selection, and argument-shape metrics.

## What's deferred

- Metrics collection and result storage
- Multiple scenarios / scenario library (only one `--query` run at a time)
- OTel instrumentation
- Retry logic beyond the 5-iteration cap
- Tests for the harness itself (it's a script, not a library)

## How to run

From the repo root:

\`\`\`bash
uv sync --group evals
uv run python -m clio_mcp.auth                        # one-time, if not already authed
uv run --group evals python -m evals.harness          # default query
uv run --group evals python -m evals.harness --query "find contacts named Smith"
\`\`\`

Requires `ANTHROPIC_API_KEY` in `.env`. The server subprocess inherits the harness's environment, so `CLIO_*` vars propagate automatically. No Anthropic API calls were made during this PR.

## Test plan

- [x] `uv sync --group evals` resolves cleanly
- [x] `uv run --group evals python -c "import evals.harness"` succeeds
- [x] `uv run --group evals python -m evals.harness --help` prints the argparse summary
- [x] `uv run pytest` passes (no changes under `src/` or `tests/`)
- [x] Manual run with a real `ANTHROPIC_API_KEY` and authed Clio tokens produces tool-call traces and a final response — verified end-to-end. Run surfaced a pre-existing bug in `client.search_matters` (list endpoints return null nested refs without `fields=` expansion), tracked in follow-up PR