### PR TITLE
fix(client): request full nested fields on matters/contacts list endpoints

### DIFF
--- a/src/clio_mcp/client.py
+++ b/src/clio_mcp/client.py
@@ -17,6 +17,25 @@ from clio_mcp.models import Contact, Matter
 
 _contact_adapter: TypeAdapter[Contact] = TypeAdapter(Contact)
 
+# Clio list endpoints return minimal payloads by default — nested refs
+# come back as null unless the caller names the fields it wants. These
+# specs mirror what the Matter / Contact models actually declare so the
+# response parses into fully populated objects.
+MATTER_FIELDS = (
+    "id,display_number,description,status,"
+    "open_date,close_date,billable,billing_method,"
+    "created_at,updated_at,"
+    "client{id,name},practice_area{id,name},"
+    "responsible_attorney{id,name},originating_attorney{id,name}"
+)
+
+CONTACT_FIELDS = (
+    "id,type,primary_email_address,primary_phone_number,"
+    "created_at,updated_at,"
+    "first_name,last_name,prefix,middle_name,suffix,date_of_birth,"
+    "name"
+)
+
 
 class ClioClient:
     """Async HTTP wrapper for Clio's main API.
@@ -44,7 +63,7 @@ class ClioClient:
         payload = await self._request(
             "GET",
             "/matters.json",
-            params={"query": query, "limit": limit},
+            params={"query": query, "limit": limit, "fields": MATTER_FIELDS},
         )
         return [Matter.model_validate(item) for item in payload["data"]]
 
@@ -58,7 +77,11 @@ class ClioClient:
         type: str | None = None,
         limit: int = 25,
     ) -> list[Contact]:
-        params: dict[str, Any] = {"query": query, "limit": limit}
+        params: dict[str, Any] = {
+            "query": query,
+            "limit": limit,
+            "fields": CONTACT_FIELDS,
+        }
         if type is not None:
             params["type"] = type
         payload = await self._request("GET", "/contacts.json", params=params)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,7 @@ import respx
 from clio_mcp.auth.client import ClioAuthClient
 from clio_mcp.auth.models import ClioConfig, ClioTokens
 from clio_mcp.auth.token_store import TokenStore
-from clio_mcp.client import ClioClient
+from clio_mcp.client import CONTACT_FIELDS, MATTER_FIELDS, ClioClient
 from clio_mcp.exceptions import ClioAPIError, ClioNotFoundError
 from clio_mcp.models import ContactCompany, ContactPerson, Matter
 
@@ -130,6 +130,33 @@ class TestSearchMatters:
         request = route.calls[0].request
         assert request.url.params["query"] == "Smith"
         assert request.url.params["limit"] == "10"
+        assert request.url.params["fields"] == MATTER_FIELDS
+
+    @respx.mock
+    async def test_parses_nested_refs_from_expanded_payload(
+        self, client: ClioClient
+    ) -> None:
+        expanded = {
+            **MATTER_PAYLOAD,
+            "responsible_attorney": {"id": 11, "name": "Attorney A"},
+            "originating_attorney": {"id": 12, "name": "Attorney B"},
+        }
+        respx.get("https://app.clio.com/api/v4/matters.json").mock(
+            return_value=httpx.Response(200, json={"data": [expanded]})
+        )
+
+        matters = await client.search_matters("Smith")
+
+        assert len(matters) == 1
+        matter = matters[0]
+        assert matter.client.id == 42
+        assert matter.client.name == "Smith, John"
+        assert matter.practice_area.id == 7
+        assert matter.practice_area.name == "Litigation"
+        assert matter.responsible_attorney.id == 11
+        assert matter.responsible_attorney.name == "Attorney A"
+        assert matter.originating_attorney.id == 12
+        assert matter.originating_attorney.name == "Attorney B"
 
 
 class TestGetContact:
@@ -192,6 +219,7 @@ class TestSearchContacts:
         request = route.calls[0].request
         assert request.url.params["query"] == "Smith"
         assert request.url.params["limit"] == "10"
+        assert request.url.params["fields"] == CONTACT_FIELDS
         assert "type" not in request.url.params
 
     @respx.mock
@@ -209,6 +237,38 @@ class TestSearchContacts:
         assert request.url.params["query"] == "Acme"
         assert request.url.params["type"] == "Company"
         assert request.url.params["limit"] == "5"
+        assert request.url.params["fields"] == CONTACT_FIELDS
+
+    @respx.mock
+    async def test_parses_populated_person_and_company_fields(
+        self, client: ClioClient
+    ) -> None:
+        populated_person = {
+            **PERSON_PAYLOAD,
+            "prefix": "Dr.",
+            "middle_name": "Q",
+            "suffix": "Jr.",
+            "date_of_birth": "1980-05-01",
+        }
+        populated_company = {**COMPANY_PAYLOAD, "primary_email_address": "info@acme.example"}
+        respx.get("https://app.clio.com/api/v4/contacts.json").mock(
+            return_value=httpx.Response(
+                200, json={"data": [populated_person, populated_company]}
+            )
+        )
+
+        contacts = await client.search_contacts("Smith")
+
+        person, company = contacts
+        assert isinstance(person, ContactPerson)
+        assert person.prefix == "Dr."
+        assert person.middle_name == "Q"
+        assert person.suffix == "Jr."
+        assert person.date_of_birth is not None
+        assert person.date_of_birth.isoformat() == "1980-05-01"
+        assert isinstance(company, ContactCompany)
+        assert company.name == "Acme LLC"
+        assert company.primary_email_address == "info@acme.example"
 
 
 class InMemoryTokenStore(TokenStore):


### PR DESCRIPTION
## Summary

- **Bug:** `search_matters` and `search_contacts` returned matters/contacts whose nested refs (client, practice_area, responsible_attorney, originating_attorney on matters; etc.) came back populated as `null`. Clio's list endpoints return minimal payloads unless the caller names the fields it wants via a `fields=` query parameter — `get_matter` / `get_contact` were fine because single-resource endpoints return full data by default.
- **Found:** first eval harness run against live data scaffolded in #13 — the model could locate matters by name but every nested reference came back empty, which made downstream reasoning impossible.
- **Fix:** module-level `MATTER_FIELDS` and `CONTACT_FIELDS` constants in `client.py` that mirror what the Pydantic models declare, passed as `fields=` on `/matters.json` and `/contacts.json`. No model changes — the models were already correct, the client just wasn't asking for the data.

Surfaced by #13.

## Test plan

- [x] `uv run pytest` — 62 passed
- [x] `respx` assertions confirm `fields=` is sent with the expected value on both list endpoints (including the type-filter variant)
- [x] New test feeds a fully-expanded mock payload and verifies nested refs (`client`, `practice_area`, `responsible_attorney`, `originating_attorney`) parse through to `Matter`
- [x] New test feeds populated `ContactPerson` + `ContactCompany` fields and verifies they parse through
- [x] Re-run eval harness against live data after merge to confirm nested refs now come back populated