### PR TITLE
feat(evals): add TestCase, CaseResult, TurnRecord models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ dist/
 *.egg-info/
 .venv/
 .DS_Store
+
+# Eval artifacts
+evals/runs/

--- a/evals/cases.py
+++ b/evals/cases.py
@@ -1,0 +1,48 @@
+"""Eval case and result models.
+
+Data shapes the harness consumes: a `TestCase` describes a committed
+eval scenario, a `TurnRecord` captures one tool call within the agent
+loop, and a `CaseResult` collects the full run output for later scoring
+and persistence. Tool results are kept at full fidelity here;
+confidentiality is enforced by gitignoring `evals/runs/`, not by
+redacting at capture time.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class TurnRecord(BaseModel):
+    tool_name: str
+    tool_args: dict[str, Any]
+    tool_result: Any
+    latency_ms: float
+
+
+class TestCase(BaseModel):
+    name: str
+    query: str
+    expected_tool: str
+    expected_args_subset: dict[str, Any]
+
+
+class CaseResult(BaseModel):
+    case_name: str
+    prompt: str
+    turns: list[TurnRecord]
+    final_text: str
+    scores: dict[str, bool] = Field(default_factory=dict)
+    iterations: int
+    wall_time_ms: float
+    completed: bool
+
+
+CASES: list[TestCase] = [
+    TestCase(
+        name="search_matters_paxos",
+        query="find the Paxos matter",
+        expected_tool="search_matters",
+        expected_args_subset={"query": "Paxos"},
+    ),
+]


### PR DESCRIPTION
## Summary
- Introduces `evals/cases.py` with the data shapes the harness refactor (next PR) will consume: `TurnRecord`, `TestCase`, and `CaseResult`.
- Seeds `CASES` with a single `search_matters_paxos` scenario. A second case is deferred to a follow-up PR.
- Purely additive — `evals/harness.py` is unchanged; the harness starts using these models in the next PR.

## Design notes
- **Full-fidelity `tool_result` capture is intentional.** `TurnRecord.tool_result` stores the raw result from `mcp.ClientSession.call_tool` without redaction or truncation. Confidentiality is enforced by the gitignore on `evals/runs/` (landed in the previous commit), not by redaction at capture time — truncating at the model layer would lose signal we need for scoring and debugging.
- **Subset-match semantics on `expected_args_subset` are intentional.** Scoring checks that the expected args appear in the actual call, not that the args are equal. Equality would penalize the model for correctly passing additional valid args (e.g. pagination parameters, field selectors) alongside the required ones.

## Test plan
- [x] `uv run pytest` passes (62 tests)
- [x] `from evals.cases import CASES, TestCase, CaseResult, TurnRecord` imports cleanly and `CASES` contains the seed entry
- [ ] Follow-up PR: harness consumes these models and writes `CaseResult` instances to `evals/runs/`