### PR TITLE
chore: add pre-commit hooks to block client names and secrets

### DIFF
--- a/.client-names.example
+++ b/.client-names.example
@@ -1,0 +1,17 @@
+# Client name denylist for the block-client-names pre-commit hook.
+# Copy this file to `.client-names` (gitignored) and add one client
+# name per line. Matching is case-insensitive and whole-word.
+#
+# Add names of:
+# - Clients whose data this project might touch (eval fixtures,
+#   manual test queries, daily notes copied into commits)
+# - Clients currently top-of-mind whose names might slip into a
+#   placeholder by accident
+#
+# This is defense-in-depth, not a complete audit. CLAUDE.md's
+# confidentiality guidance still applies; the hook catches the
+# subset of mistakes that are exact-string matches.
+#
+# Example entries (delete and replace with real ones):
+# Acme Corp
+# Widget LLC

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ dist/
 
 # Eval artifacts
 evals/runs/
+
+# Local-only client name denylist (pre-commit hook reads this)
+.client-names

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,3 +29,8 @@ repos:
             exit 1
           fi
           ' --
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,13 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      - id: block-client-names
+        name: Block client names from denylist
+        entry: scripts/check_client_names.py
+        language: python
+        pass_filenames: true
+        stages: [pre-commit]
+
       - id: conventional-commit
         name: Conventional Commits format
         language: system

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,9 @@ This repo is public. The following must not appear in any committed file, commit
 
 In examples, docstrings, tests, and fixtures, use generic placeholders: "Acme", "Smith", "Example LLC". Test data is synthetic.
 
-Before committing, grep the diff for anything that looks like a proper noun you didn't invent. Pre-commit hooks will not catch this — it's a human judgment check.
+Before committing, grep the diff for anything that looks like a proper noun you didn't invent. This is primarily a human judgment check.
+
+A `block-client-names` pre-commit hook provides a mechanical backstop: it refuses commits that contain any term listed in the local `.client-names` file (gitignored, per-clone). The hook is defense-in-depth and only catches exact-string whole-word matches — partial matches, paraphrases, and non-name identifiers (matter IDs, distinctive case facts) still depend on the principle above. `.client-names.example` documents the format; README.md has setup steps.
 
 The server runs against live Clio data. Treat all tool inputs and
 outputs as sensitive downstream of the machine. This applies to every

--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ _Coming soon_
 
 _Coming soon_
 
+## Contributing / Local setup
+
+```bash
+uv sync --group dev          # install dev dependencies (includes pre-commit)
+uv run pre-commit install --hook-type pre-commit --hook-type commit-msg
+
+cp .client-names.example .client-names
+# Edit .client-names to list client names the hook should block.
+```
+
+The `block-client-names` pre-commit hook reads `.client-names` (gitignored) and refuses commits that contain any listed name as a case-insensitive whole-word match. The denylist is per-clone and must be populated locally; `.client-names.example` documents the format. The hook is defense-in-depth — see the confidentiality section of `CLAUDE.md` for the broader rules.
+
 ## Data handling
 
 This server runs locally over stdio; no data transits through any infrastructure operated by this project's author. Tool responses flow from the Clio API to the local process to the user's Claude client, subject to that client's data handling terms. Observability is via self-hosted [Arize Phoenix](https://phoenix.arize.com/); traces do not leave the user's machine.

--- a/scripts/check_client_names.py
+++ b/scripts/check_client_names.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Block commits that contain client names on a local denylist.
+
+The denylist lives at `.client-names` (gitignored). Each non-blank,
+non-comment line is a term matched case-insensitively as a whole word
+against the content of every staged file passed on the command line.
+
+Defense-in-depth only: the confidentiality principle in CLAUDE.md still
+governs anything the hook does not catch (partial matches, paraphrases,
+non-name identifiers, new names not yet added to the denylist).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DENYLIST_PATH = REPO_ROOT / ".client-names"
+SCRIPT_PATH = Path(__file__).resolve()
+
+
+def load_denylist(path: Path) -> list[str]:
+    terms: list[str] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        terms.append(line)
+    return terms
+
+
+def compile_patterns(terms: list[str]) -> list[tuple[str, re.Pattern[str]]]:
+    return [
+        (term, re.compile(rf"\b{re.escape(term)}\b", re.IGNORECASE))
+        for term in terms
+    ]
+
+
+def scan_file(
+    path: Path, patterns: list[tuple[str, re.Pattern[str]]]
+) -> list[tuple[str, int]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (UnicodeDecodeError, OSError):
+        return []
+
+    hits: list[tuple[str, int]] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for term, pattern in patterns:
+            if pattern.search(line):
+                hits.append((term, lineno))
+    return hits
+
+
+def main(argv: list[str]) -> int:
+    if not DENYLIST_PATH.exists():
+        print(
+            "WARNING: .client-names not found; client-name check skipped. "
+            "Create it to enable enforcement.",
+            file=sys.stderr,
+        )
+        return 0
+
+    terms = load_denylist(DENYLIST_PATH)
+    if not terms:
+        return 0
+
+    patterns = compile_patterns(terms)
+    total_hits = 0
+
+    for arg in argv:
+        file_path = Path(arg)
+        if not file_path.is_file():
+            continue
+
+        resolved = file_path.resolve()
+        if resolved == DENYLIST_PATH.resolve() or resolved == SCRIPT_PATH:
+            continue
+
+        for term, lineno in scan_file(file_path, patterns):
+            print(
+                f"BLOCKED: {file_path} contains client name "
+                f"'{term}' on line {lineno}",
+                file=sys.stderr,
+            )
+            total_hits += 1
+
+    if total_hits:
+        print(
+            f"Commit blocked: {total_hits} client-name match(es) found. "
+            "Remove the matches or use `git commit --no-verify` to bypass "
+            "(not recommended for this repo).",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Why

CLAUDE.md's confidentiality rules rely on human judgment to catch violations in committed code. This PR adds hard enforcement at the git layer via pre-commit hooks, a denylist-based check for client names and a gitleaks scan for credentials. Hard enforcement catches the class of mistakes where a real identifier slips past model + human review into a staged diff.

## What this adds

- **`block-client-names`** (local hook): scans staged files for case-insensitive whole-word matches against terms in a local `.client-names` denylist. Prints `BLOCKED: <file> contains client name '<term>' on line <n>` and exits 1 on any hit. Safe on fresh clones — if `.client-names` is absent, the hook prints a warning and exits 0.
- **`gitleaks` v8.30.1**: secret scanning on every commit as a second backstop.
- **`.client-names.example`**: committed template documenting the denylist format. Actual `.client-names` is gitignored and maintained per-clone.
- **Docs**: README "Contributing / Local setup" section; CLAUDE.md confidentiality section names the hook as the mechanical backstop and states what it does not catch.

## What the hook catches

- Exact-string, case-insensitive, whole-word matches against the local denylist.

## What the hook does NOT catch

- Names not yet added to the denylist.
- Partial matches, paraphrases, substrings.
- Non-name identifiers (matter IDs, distinctive case facts, sandbox names).
- `git commit --no-verify` bypass.

The confidentiality principle in CLAUDE.md still governs everything in the second list.

## Test plan

- [x] `uv run pytest` passes (62 tests)
- [x] Direct script run blocks a file containing a denylisted term (exit 1, formatted message) and exits 0 on a clean file
- [x] Full `git commit` flow blocks a throwaway commit with a denylisted term and succeeds once the term is removed
- [x] `pre-commit run --all-files` passes against the current tree
- [x] Clean working tree after reverting the throwaway test commit and scratch file