### PR TITLE
feat(evals): add search_contacts_company routing case

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,13 @@ This repo is public. The following must not appear in any committed file, commit
 - Real IDs that could be linked back to actual Clio records
 - Environment-specific identifiers (sandbox names, workspace names)
 
-In examples, docstrings, tests, and fixtures, use generic placeholders: "Acme", "Smith", "Example LLC". Test data is synthetic.
+In examples, docstrings, tests, and fixtures, use generic placeholders. Test data is synthetic. Canonical placeholders:
+
+- "Acme" — companies, organizations, firms, and any other non-person entity.
+- "Smith" — person surnames (e.g., "Jane Smith").
+- "Example LLC" — acceptable long-form organization placeholder when "Acme" would be ambiguous.
+
+Prefer these over ad-hoc inventions so eval prompts and fixtures stay internally consistent: a prompt that says "the Acme matter" unambiguously means a company, and one that says "Jane Smith" unambiguously means a person.
 
 Before committing, grep the diff for anything that looks like a proper noun you didn't invent. This is primarily a human judgment check.
 

--- a/evals/cases.py
+++ b/evals/cases.py
@@ -52,4 +52,10 @@ CASES: list[TestCase] = [
         expected_tool="search_matters",
         expected_args_subset={"query": "Acme"},
     ),
+    TestCase(
+        name="search_contacts_company",
+        query="find the Acme company in my contacts",
+        expected_tool="search_contacts",
+        expected_args_subset={"query": "Acme", "type": "Company"},
+    ),
 ]


### PR DESCRIPTION
## Summary
- Adds a second committed eval case (`search_contacts_company`) that forces a real routing decision: prompt "find the Acme company in my contacts" → `search_contacts` with `{"query": "Acme", "type": "Company"}`. Both axes (tool choice, typed filter) have an unambiguous expected behavior.
- Extends CLAUDE.md's confidentiality section to name "Acme" as the canonical company placeholder and "Smith" as the canonical person placeholder, so future eval prompts can rely on those cues without collision.
- A `search_contacts_person` counterpart was prototyped and dropped — "find the contact for Jane Smith" has no single defensible expected behavior (surname vs full-name query, implicit vs explicit `type` inference) and forcing one via a prescriptive docstring change would violate the slim-tools philosophy. Revisit once the tool contract for name handling is settled.

## Test plan
- [x] `uv run pytest` — 76 passed
- [x] `uv run --group evals python -m evals.harness` against live Clio:
  - `search_matters_generic_term`: TOOL=PASS ARGS=PASS DONE=PASS (tool_succeeded=PASS, 2 iter, 6979.9 ms)
  - `search_contacts_company`: TOOL=PASS ARGS=PASS DONE=PASS (tool_succeeded=PASS, 2 iter, 8604.6 ms)