### PR TITLE
fix(client): remove invalid suffix field from CONTACT_FIELDS

### DIFF
--- a/src/clio_mcp/client.py
+++ b/src/clio_mcp/client.py
@@ -30,10 +30,9 @@ MATTER_FIELDS = (
 )
 
 CONTACT_FIELDS = (
-    "id,type,primary_email_address,primary_phone_number,"
-    "created_at,updated_at,"
-    "first_name,last_name,prefix,middle_name,suffix,date_of_birth,"
-    "name"
+    "id,type,name,"
+    "first_name,last_name,"
+    "primary_email_address,primary_phone_number"
 )
 
 


### PR DESCRIPTION
## Summary
- Clio's `/contacts.json` rejects `suffix` as an invalid field, causing every `search_contacts` call to fail with a 400 `InvalidFields` error.
- Drop `suffix` plus the other unused fields (`prefix`, `middle_name`, `date_of_birth`, `created_at`, `updated_at`) that the `Contact` model does not reference. Keep `id`, `type`, `name`, `first_name`, `last_name`, `primary_email_address`, `primary_phone_number`.

## Test plan
- [x] `uv run pytest` — 71 passed
- [x] `uv run --group evals python -m evals.harness` against live Clio (with `search_contacts_person_filter` case temporarily staged locally to verify):
  - `search_matters_generic_term`: TOOL=PASS ARGS=PASS DONE=PASS (2 iter, 8998.7ms)
  - `search_contacts_person_filter`: TOOL=PASS ARGS=PASS DONE=PASS (2 iter, 7969.7ms — down from 3 iter; no more 400 retry loop)