### PR TITLE
feat(evals): add tool_succeeded scoring axis

### DIFF
--- a/evals/scoring.py
+++ b/evals/scoring.py
@@ -12,22 +12,26 @@ from evals.cases import CaseResult, TestCase
 def score(case: TestCase, result: CaseResult) -> dict[str, bool]:
     """Score a CaseResult against its TestCase expectations.
 
-    Returns three booleans:
+    Returns four booleans:
 
     - ``tool_match``: the first tool call matches ``case.expected_tool``.
     - ``args_match``: every ``(k, v)`` in ``case.expected_args_subset``
       is present in the first call's arguments with the expected value.
       Subset semantics — extra valid args in the actual call do not
       fail the check; a missing key or mismatched value does.
+    - ``tool_succeeded``: the first turn's ``tool_result`` is a dict
+      with ``isError`` set to False. Absent ``isError`` or a non-dict
+      result is treated as failure, not silent success.
     - ``completed``: copy of ``result.completed``.
 
-    If ``result.turns`` is empty, both ``tool_match`` and ``args_match``
-    are False. Mutates ``result.scores`` in place and returns the same
-    dict for convenience at the call site.
+    If ``result.turns`` is empty, ``tool_match``, ``args_match``, and
+    ``tool_succeeded`` are all False. Mutates ``result.scores`` in
+    place and returns the same dict for convenience at the call site.
     """
     if not result.turns:
         tool_match = False
         args_match = False
+        tool_succeeded = False
     else:
         first = result.turns[0]
         tool_match = first.tool_name == case.expected_tool
@@ -35,10 +39,16 @@ def score(case: TestCase, result: CaseResult) -> dict[str, bool]:
             k in first.tool_args and first.tool_args[k] == v
             for k, v in case.expected_args_subset.items()
         )
+        tool_result = first.tool_result
+        if isinstance(tool_result, dict):
+            tool_succeeded = not tool_result.get("isError", True)
+        else:
+            tool_succeeded = False
 
     scores = {
         "tool_match": tool_match,
         "args_match": args_match,
+        "tool_succeeded": tool_succeeded,
         "completed": result.completed,
     }
     result.scores = scores

--- a/tests/test_evals_score.py
+++ b/tests/test_evals_score.py
@@ -23,14 +23,20 @@ def _case(
     )
 
 
+_UNSET: Any = object()
+
+
 def _turn(
     name: str = "search_matters",
     args: dict[str, Any] | None = None,
+    tool_result: Any = _UNSET,
 ) -> TurnRecord:
+    if tool_result is _UNSET:
+        tool_result = {"isError": False, "content": []}
     return TurnRecord(
         tool_name=name,
         tool_args=args or {},
-        tool_result=None,
+        tool_result=tool_result,
         latency_ms=0.0,
     )
 
@@ -56,7 +62,12 @@ def test_empty_turns_yields_all_false() -> None:
 
     scores = score(case, result)
 
-    assert scores == {"tool_match": False, "args_match": False, "completed": False}
+    assert scores == {
+        "tool_match": False,
+        "args_match": False,
+        "tool_succeeded": False,
+        "completed": False,
+    }
     assert result.scores == scores
 
 
@@ -136,3 +147,59 @@ def test_empty_expected_subset_matches_any_args() -> None:
     scores = score(case, result)
 
     assert scores["args_match"] is True
+
+
+def test_tool_succeeded_true_when_first_turn_not_errored() -> None:
+    case = _case()
+    result = _result(turns=[_turn(tool_result={"isError": False, "content": []})])
+
+    scores = score(case, result)
+
+    assert scores["tool_succeeded"] is True
+
+
+def test_tool_succeeded_false_when_first_turn_errored() -> None:
+    case = _case()
+    result = _result(turns=[_turn(tool_result={"isError": True, "content": []})])
+
+    scores = score(case, result)
+
+    assert scores["tool_succeeded"] is False
+
+
+def test_tool_succeeded_false_when_is_error_key_missing() -> None:
+    case = _case()
+    result = _result(turns=[_turn(tool_result={"content": []})])
+
+    scores = score(case, result)
+
+    assert scores["tool_succeeded"] is False
+
+
+def test_tool_succeeded_false_when_tool_result_is_not_a_dict() -> None:
+    case = _case()
+    result = _result(turns=[_turn(tool_result=None)])
+
+    scores = score(case, result)
+
+    assert scores["tool_succeeded"] is False
+
+    result = _result(turns=[_turn(tool_result="some string")])
+
+    scores = score(case, result)
+
+    assert scores["tool_succeeded"] is False
+
+
+def test_tool_succeeded_only_considers_first_turn() -> None:
+    case = _case()
+    result = _result(
+        turns=[
+            _turn(tool_result={"isError": True, "content": []}),
+            _turn(tool_result={"isError": False, "content": []}),
+        ],
+    )
+
+    scores = score(case, result)
+
+    assert scores["tool_succeeded"] is False


### PR DESCRIPTION
## Summary
- Extend `evals/scoring.py::score()` with a fourth boolean `tool_succeeded` that reflects whether the first turn's `tool_result` has `isError=False`. Absent `isError`, non-dict results, and empty turns all score False — no silent passes.
- Closes the blind spot exposed by #20: both tool calls were erroring with 400s while `tool_match`, `args_match`, and `completed` all scored PASS.
- Harness output formatting unchanged; adding the fifth column in the printed table is a follow-up so this PR stays scoped to scoring logic.

## Test plan
- [x] `uv run pytest` — 76 passed (9 prior score tests + 5 new ones covering the new axis)
- [x] New tests cover: empty turns, `isError=False`, `isError=True`, missing `isError` key, non-dict `tool_result` (None and string), and that only the first turn's `isError` is considered