### PR TITLE
fix(matters): include fields= param in get_matter request

### DIFF
--- a/src/clio_mcp/client.py
+++ b/src/clio_mcp/client.py
@@ -55,7 +55,11 @@ class ClioClient:
         self._auth_client = auth_client or ClioAuthClient(config)
 
     async def get_matter(self, matter_id: int) -> Matter:
-        payload = await self._request("GET", f"/matters/{matter_id}.json")
+        payload = await self._request(
+            "GET",
+            f"/matters/{matter_id}.json",
+            params={"fields": MATTER_FIELDS},
+        )
         return Matter.model_validate(payload["data"])
 
     async def search_matters(self, query: str, limit: int = 25) -> list[Matter]:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -88,6 +88,26 @@ class TestGetMatter:
         assert sent_auth == "Bearer fake-access-token"
 
     @respx.mock
+    async def test_requests_expanded_fields(self, client: ClioClient) -> None:
+        route = respx.get("https://app.clio.com/api/v4/matters/123.json").mock(
+            return_value=httpx.Response(200, json={"data": MATTER_PAYLOAD})
+        )
+
+        await client.get_matter(123)
+
+        request = route.calls[0].request
+        assert request.url.params["fields"] == MATTER_FIELDS
+        fields = request.url.params["fields"]
+        for expected in (
+            "description",
+            "status",
+            "billable",
+            "client",
+            "responsible_attorney",
+        ):
+            assert expected in fields
+
+    @respx.mock
     async def test_raises_not_found_on_404(self, client: ClioClient) -> None:
         respx.get("https://app.clio.com/api/v4/matters/999.json").mock(
             return_value=httpx.Response(404, text='{"error":"not found"}')


### PR DESCRIPTION
## What

Adds a `fields=` query param to `get_matter`, mirroring the field list already used by `search_matters`. Without it, Clio's get-by-id endpoint returns a minimal projection — only `id`, `display_number`, and `etag` populate.

## Why

Discovered during Claude Code dogfooding: a `get_matter` call returned null for description, status, client, practice area, attorneys, dates, and billing fields. The same matter, fetched seconds earlier from `search_matters`, returned all fields populated. Phoenix trace confirmed the get-by-id URL had no query string at all, while `search_matters` had `fields=...` with the full list.

## Tests

Unit test asserts the outgoing `get_matter` request URL includes `fields=` with the expected field names.

## Future

Worth committing a `get_matter`-specific eval case once this lands — neither of the two existing committed cases routes to `get_matter`, which is why this gap wasn't caught by evals.