### PR TITLE
feat(evals): add result-shape check to eval scorer

### DIFF
--- a/evals/cases.py
+++ b/evals/cases.py
@@ -32,6 +32,7 @@ class TestCase(BaseModel):
     query: str
     expected_tool: str
     expected_args_subset: dict[str, Any]
+    expected_non_null_fields: list[str] = Field(default_factory=list)
 
 
 class CaseResult(BaseModel):
@@ -57,5 +58,23 @@ CASES: list[TestCase] = [
         query="find the Acme company in my contacts",
         expected_tool="search_contacts",
         expected_args_subset={"query": "Acme", "type": "Company"},
+    ),
+    TestCase(
+        name="get_matter_by_id",
+        query="Give me details on matter 1668402907",
+        expected_tool="get_matter",
+        expected_args_subset={"matter_id": 1668402907},
+        expected_non_null_fields=["description", "status"],
+    ),
+    TestCase(
+        name="get_contact_by_id",
+        query="Give me details on contact 1809175816",
+        expected_tool="get_contact",
+        expected_args_subset={"contact_id": 1809175816},
+        expected_non_null_fields=[
+            "first_name",
+            "last_name",
+            "primary_email_address",
+        ],
     ),
 ]

--- a/evals/harness.py
+++ b/evals/harness.py
@@ -176,11 +176,15 @@ def persist_run(
 
     tool_match_passes = sum(1 for r in results if r.scores.get("tool_match"))
     args_match_passes = sum(1 for r in results if r.scores.get("args_match"))
+    result_match_passes = sum(1 for r in results if r.scores.get("result_match"))
     completed_passes = sum(1 for r in results if r.scores.get("completed"))
     all_passed = sum(
         1
         for r in results
-        if all(r.scores.get(k) for k in ("tool_match", "args_match", "completed"))
+        if all(
+            r.scores.get(k)
+            for k in ("tool_match", "args_match", "result_match", "completed")
+        )
     )
 
     payload = {
@@ -194,6 +198,7 @@ def persist_run(
             "total": len(results),
             "tool_match_passes": tool_match_passes,
             "args_match_passes": args_match_passes,
+            "result_match_passes": result_match_passes,
             "completed_passes": completed_passes,
             "all_passed": all_passed,
         },
@@ -208,15 +213,17 @@ def persist_run(
 def _print_summary(results: list[CaseResult]) -> None:
     """Print a plain-text summary table for a list of scored results."""
     header = (
-        f"{'CASE':<40}{'TOOL':<8}{'ARGS':<8}{'DONE':<8}{'ITER':<8}{'TIME_MS'}"
+        f"{'CASE':<40}{'TOOL':<8}{'ARGS':<8}{'RESULT':<8}"
+        f"{'DONE':<8}{'ITER':<8}{'TIME_MS'}"
     )
     print(header)
     for r in results:
         tool = "PASS" if r.scores.get("tool_match") else "FAIL"
         args_col = "PASS" if r.scores.get("args_match") else "FAIL"
+        result_col = "PASS" if r.scores.get("result_match") else "FAIL"
         done = "PASS" if r.scores.get("completed") else "FAIL"
         print(
-            f"{r.case_name:<40}{tool:<8}{args_col:<8}{done:<8}"
+            f"{r.case_name:<40}{tool:<8}{args_col:<8}{result_col:<8}{done:<8}"
             f"{r.iterations:<8}{r.wall_time_ms:.1f}"
         )
 

--- a/evals/scoring.py
+++ b/evals/scoring.py
@@ -6,27 +6,77 @@ dependencies (anthropic, mcp) that the harness needs at live-run
 time.
 """
 
-from evals.cases import CaseResult, TestCase
+from typing import Any
+
+from evals.cases import CaseResult, TestCase, TurnRecord
+
+
+def _extract_payload(tool_result: Any) -> Any:
+    """Unwrap an MCP CallToolResult dump down to the tool's actual return.
+
+    FastMCP wraps any non-dict return (lists, discriminated unions) as
+    ``{"result": <value>}`` and sets ``meta.fastmcp.wrap_result``. For
+    Pydantic models that already serialize to a dict, ``structuredContent``
+    holds the model fields directly. This helper hides that distinction
+    so result-shape checks see the data the tool returned.
+    """
+    if not isinstance(tool_result, dict):
+        return None
+    structured = tool_result.get("structuredContent")
+    if structured is None:
+        return None
+    meta = tool_result.get("meta") or {}
+    wrapped = meta.get("fastmcp", {}).get("wrap_result", False)
+    if wrapped and isinstance(structured, dict) and "result" in structured:
+        return structured["result"]
+    return structured
+
+
+def _result_match(case: TestCase, turns: list[TurnRecord]) -> bool:
+    matching = next((t for t in turns if t.tool_name == case.expected_tool), None)
+    if matching is None:
+        return False
+    if not case.expected_non_null_fields:
+        return True
+    payload = _extract_payload(matching.tool_result)
+    # List-shape checks are deliberately out of scope for v1: a non-empty
+    # expected_non_null_fields against a list result means the case was
+    # configured for a get-by-id-style tool but pointed at a search tool.
+    if isinstance(payload, list):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    return all(
+        field in payload and payload[field] is not None
+        for field in case.expected_non_null_fields
+    )
 
 
 def score(case: TestCase, result: CaseResult) -> dict[str, bool]:
     """Score a CaseResult against its TestCase expectations.
 
-    Returns four booleans:
+    Returns five booleans:
 
     - ``tool_match``: the first tool call matches ``case.expected_tool``.
     - ``args_match``: every ``(k, v)`` in ``case.expected_args_subset``
       is present in the first call's arguments with the expected value.
       Subset semantics — extra valid args in the actual call do not
       fail the check; a missing key or mismatched value does.
+    - ``result_match``: the first turn whose ``tool_name`` matches
+      ``case.expected_tool`` returned a dict containing every field in
+      ``case.expected_non_null_fields`` with a non-null value. Missing
+      keys are treated as null. Empty ``expected_non_null_fields`` is
+      vacuous truth (matches the args-subset semantics). False when
+      the expected tool was not called.
     - ``tool_succeeded``: the first turn's ``tool_result`` is a dict
       with ``isError`` set to False. Absent ``isError`` or a non-dict
       result is treated as failure, not silent success.
     - ``completed``: copy of ``result.completed``.
 
-    If ``result.turns`` is empty, ``tool_match``, ``args_match``, and
-    ``tool_succeeded`` are all False. Mutates ``result.scores`` in
-    place and returns the same dict for convenience at the call site.
+    If ``result.turns`` is empty, ``tool_match``, ``args_match``,
+    ``result_match``, and ``tool_succeeded`` are all False. Mutates
+    ``result.scores`` in place and returns the same dict for
+    convenience at the call site.
     """
     if not result.turns:
         tool_match = False
@@ -48,6 +98,7 @@ def score(case: TestCase, result: CaseResult) -> dict[str, bool]:
     scores = {
         "tool_match": tool_match,
         "args_match": args_match,
+        "result_match": _result_match(case, result.turns),
         "tool_succeeded": tool_succeeded,
         "completed": result.completed,
     }

--- a/tests/test_evals_score.py
+++ b/tests/test_evals_score.py
@@ -14,13 +14,35 @@ from evals.scoring import score
 def _case(
     expected_tool: str = "search_matters",
     subset: dict[str, Any] | None = None,
+    non_null_fields: list[str] | None = None,
 ) -> TestCase:
     return TestCase(
         name="t",
         query="q",
         expected_tool=expected_tool,
         expected_args_subset=subset or {},
+        expected_non_null_fields=non_null_fields or [],
     )
+
+
+def _dict_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    """Mimic an MCP CallToolResult dump whose tool returned a dict-shaped model."""
+    return {
+        "meta": None,
+        "content": [{"type": "text", "text": "{}"}],
+        "structuredContent": payload,
+        "isError": False,
+    }
+
+
+def _list_payload(items: list[Any]) -> dict[str, Any]:
+    """Mimic an MCP CallToolResult dump whose tool returned a list (FastMCP wraps it)."""
+    return {
+        "meta": {"fastmcp": {"wrap_result": True}},
+        "content": [{"type": "text", "text": "[]"}],
+        "structuredContent": {"result": items},
+        "isError": False,
+    }
 
 
 _UNSET: Any = object()
@@ -65,6 +87,7 @@ def test_empty_turns_yields_all_false() -> None:
     assert scores == {
         "tool_match": False,
         "args_match": False,
+        "result_match": False,
         "tool_succeeded": False,
         "completed": False,
     }
@@ -203,3 +226,142 @@ def test_tool_succeeded_only_considers_first_turn() -> None:
     scores = score(case, result)
 
     assert scores["tool_succeeded"] is False
+
+
+def test_result_match_passes_when_all_listed_fields_non_null() -> None:
+    case = _case(
+        expected_tool="get_matter",
+        non_null_fields=["description", "status"],
+    )
+    result = _result(
+        turns=[
+            _turn(
+                name="get_matter",
+                tool_result=_dict_payload(
+                    {"id": 1, "description": "Acme Lend", "status": "Open"}
+                ),
+            )
+        ]
+    )
+
+    scores = score(case, result)
+
+    assert scores["result_match"] is True
+
+
+def test_result_match_fails_when_listed_field_is_null() -> None:
+    case = _case(
+        expected_tool="get_matter",
+        non_null_fields=["description", "status"],
+    )
+    result = _result(
+        turns=[
+            _turn(
+                name="get_matter",
+                tool_result=_dict_payload(
+                    {"id": 1, "description": None, "status": "Open"}
+                ),
+            )
+        ]
+    )
+
+    scores = score(case, result)
+
+    assert scores["result_match"] is False
+
+
+def test_result_match_fails_when_listed_field_is_absent() -> None:
+    case = _case(
+        expected_tool="get_matter",
+        non_null_fields=["description", "status"],
+    )
+    result = _result(
+        turns=[
+            _turn(
+                name="get_matter",
+                tool_result=_dict_payload({"id": 1, "status": "Open"}),
+            )
+        ]
+    )
+
+    scores = score(case, result)
+
+    assert scores["result_match"] is False
+
+
+def test_result_match_vacuous_with_empty_expected_fields() -> None:
+    case = _case(expected_tool="search_matters", non_null_fields=[])
+    result = _result(
+        turns=[
+            _turn(
+                name="search_matters",
+                tool_result=_list_payload([{"id": 1}]),
+            )
+        ]
+    )
+
+    scores = score(case, result)
+
+    assert scores["result_match"] is True
+
+
+def test_result_match_fails_for_list_payload_with_non_empty_expected() -> None:
+    # Misconfigured: list-shape result paired with field-level expectations.
+    case = _case(
+        expected_tool="search_matters",
+        non_null_fields=["description"],
+    )
+    result = _result(
+        turns=[
+            _turn(
+                name="search_matters",
+                tool_result=_list_payload([{"description": "Acme"}]),
+            )
+        ]
+    )
+
+    scores = score(case, result)
+
+    assert scores["result_match"] is False
+
+
+def test_result_match_fails_when_expected_tool_was_not_called() -> None:
+    case = _case(
+        expected_tool="get_matter",
+        non_null_fields=["description"],
+    )
+    result = _result(
+        turns=[
+            _turn(
+                name="search_matters",
+                tool_result=_list_payload([{"description": "Acme"}]),
+            )
+        ]
+    )
+
+    scores = score(case, result)
+
+    assert scores["result_match"] is False
+
+
+def test_result_match_unwraps_fastmcp_wrapped_dict() -> None:
+    # Discriminated unions (e.g. Contact) come back wrapped as {"result": <dict>}.
+    case = _case(
+        expected_tool="get_contact",
+        non_null_fields=["first_name", "last_name"],
+    )
+    wrapped = {
+        "meta": {"fastmcp": {"wrap_result": True}},
+        "content": [{"type": "text", "text": "{}"}],
+        "structuredContent": {
+            "result": {"first_name": "Jane", "last_name": "Smith"}
+        },
+        "isError": False,
+    }
+    result = _result(
+        turns=[_turn(name="get_contact", tool_result=wrapped)]
+    )
+
+    scores = score(case, result)
+
+    assert scores["result_match"] is True


### PR DESCRIPTION
## Summary

Extends the eval scorer with a `result_match` check that catches the bug class from #25 — get-by-id endpoints returning 200 with a nulled-out body when `fields=` is missing. Today the harness only validates tool selection and arguments; it would not have flagged that bug.

`TestCase` gets a new `expected_non_null_fields: list[str]`. The scorer walks the trajectory for the expected tool, unwraps the FastMCP envelope (`structuredContent`, plus `meta.fastmcp.wrap_result` for discriminated unions and lists), and verifies every listed field is present and non-null on the resulting dict. Top-level paths only for v1 — no dotted traversal.

Semantics:

- Tool not called → `FAIL` (not vacuous).
- Empty `expected_non_null_fields` → `PASS` (matches the existing args-subset semantics; the two `search_*` cases get this).
- Dict payload, all fields non-null → `PASS`. Missing key is treated as null.
- List payload with non-empty expectations → `FAIL`. Misconfigured case — list-shape checks are deliberately out of scope for v1.

Output adds a `RESULT` column between `ARGS` and `DONE`, and `result_match` is folded into the persisted-run `all_passed` counter alongside a new `result_match_passes` counter.

## Real bug surfaced by the new check

```
CASE                                    TOOL    ARGS    RESULT  DONE    ITER    TIME_MS
get_contact_by_id                       PASS    PASS    FAIL    PASS    2       15417.2
```

This is a real instance of the same bug class #25 fixed for `get_matter`. `get_contact` in `client.py` does not pass `fields=CONTACT_FIELDS`, so the API returns a 200 with `first_name`, `last_name`, and `primary_email_address` all null. Tool selection and args are correct — the existing checks pass — but the payload is unusable. The fix is a one-line addition to the client method and ships in a follow-up PR.

The other three cases (`search_matters_generic_term`, `search_contacts_company`, `get_matter_by_id`) pass `TOOL/ARGS/RESULT/DONE`.

## Out of scope

- Fixing `get_contact` itself — separate branch, follow-up PR.
- README updates for the eval section — handled separately once this lands.
- Dotted-path traversal into nested fields, list-shape result checks.

## Test plan

- [x] `uv run pytest` — 87 passing, including 6 new `result_match` tests (pass / null-field / missing-field / vacuous / misconfigured-list / tool-not-called) and a wrap_result-unwrap regression.
- [x] `uv run --group evals python -m evals.harness` — 3/4 cases all-green; `get_contact_by_id` `RESULT FAIL` is the surfaced bug above, not a scorer defect.