### PR TITLE
fix(contacts): include fields= param in get_contact request

### DIFF
--- a/src/clio_mcp/client.py
+++ b/src/clio_mcp/client.py
@@ -71,7 +71,11 @@ class ClioClient:
         return [Matter.model_validate(item) for item in payload["data"]]
 
     async def get_contact(self, contact_id: int) -> Contact:
-        payload = await self._request("GET", f"/contacts/{contact_id}.json")
+        payload = await self._request(
+            "GET",
+            f"/contacts/{contact_id}.json",
+            params={"fields": CONTACT_FIELDS},
+        )
         return _contact_adapter.validate_python(payload["data"])
 
     async def search_contacts(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -198,6 +198,25 @@ class TestGetContact:
         assert sent_auth == "Bearer fake-access-token"
 
     @respx.mock
+    async def test_requests_expanded_fields(self, client: ClioClient) -> None:
+        route = respx.get("https://app.clio.com/api/v4/contacts/501.json").mock(
+            return_value=httpx.Response(200, json={"data": PERSON_PAYLOAD})
+        )
+
+        await client.get_contact(501)
+
+        request = route.calls[0].request
+        assert request.url.params["fields"] == CONTACT_FIELDS
+        fields = request.url.params["fields"]
+        for expected in (
+            "type",
+            "first_name",
+            "last_name",
+            "primary_email_address",
+        ):
+            assert expected in fields
+
+    @respx.mock
     async def test_returns_parsed_company(self, client: ClioClient) -> None:
         respx.get("https://app.clio.com/api/v4/contacts/502.json").mock(
             return_value=httpx.Response(200, json={"data": COMPANY_PAYLOAD})


### PR DESCRIPTION
## Summary
- Same bug class as #25, now applied to `get_contact`. Without `fields=`, Clio's get-by-id endpoint returns a minimal projection — most attributes come back null.
- Mirrors `get_matter` post-#25: passes `params={"fields": CONTACT_FIELDS}`, reusing the constant already shared with `search_contacts`.
- Surfaced by the result-shape scorer added in #26 — `get_contact_by_id` was failing the RESULT column.

## Test plan
- [x] `uv run pytest` — 88 passed (new `test_requests_expanded_fields` mirrors the matters version).
- [x] `uv run --group evals python -m evals.harness` — full table 4/4 PASS across TOOL/ARGS/RESULT/DONE; `get_contact_by_id` flipped from RESULT FAIL to PASS.