### PR TITLE
feat(matters): add status filter to search_matters

### DIFF
--- a/src/clio_mcp/client.py
+++ b/src/clio_mcp/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import httpx
 from pydantic import TypeAdapter
@@ -62,12 +62,20 @@ class ClioClient:
         )
         return Matter.model_validate(payload["data"])
 
-    async def search_matters(self, query: str, limit: int = 25) -> list[Matter]:
-        payload = await self._request(
-            "GET",
-            "/matters.json",
-            params={"query": query, "limit": limit, "fields": MATTER_FIELDS},
-        )
+    async def search_matters(
+        self,
+        query: str,
+        limit: int = 25,
+        status: Literal["open", "pending", "closed"] | None = None,
+    ) -> list[Matter]:
+        params: dict[str, Any] = {
+            "query": query,
+            "limit": limit,
+            "fields": MATTER_FIELDS,
+        }
+        if status is not None:
+            params["status"] = status
+        payload = await self._request("GET", "/matters.json", params=params)
         return [Matter.model_validate(item) for item in payload["data"]]
 
     async def get_contact(self, contact_id: int) -> Contact:

--- a/src/clio_mcp/tools/matters.py
+++ b/src/clio_mcp/tools/matters.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Literal
+
 from clio_mcp.auth.models import ClioConfig
 from clio_mcp.client import ClioClient
 from clio_mcp.models import Matter
@@ -26,19 +28,26 @@ async def get_matter(matter_id: int) -> Matter:
     return await _get_client().get_matter(matter_id)
 
 
-async def search_matters(query: str, limit: int = 25) -> list[Matter]:
+async def search_matters(
+    query: str,
+    limit: int = 25,
+    status: Literal["open", "pending", "closed"] | None = None,
+) -> list[Matter]:
     """Search for matters by keyword. Matches against matter numbers,
     descriptions, and client names.
 
-    Pass distinctive terms — a company name, person's last name. 
+    Pass distinctive terms — a company name, person's last name.
     Do not pass full sentences or predicate expressions.
 
     Good: "Acme", "Smith"
     Bad: "all Smith matters", "client name contains Acme"
+
+    The optional status filter restricts results to matters in that
+    status; omit it to return matters of all statuses.
 
     Returns up to limit matters (default 25, max 100). Passing a limit
     above 100 raises ValueError.
     """
     if limit > 100:
         raise ValueError("limit must be 100 or fewer")
-    return await _get_client().search_matters(query, limit)
+    return await _get_client().search_matters(query, limit, status)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -151,6 +151,18 @@ class TestSearchMatters:
         assert request.url.params["query"] == "Smith"
         assert request.url.params["limit"] == "10"
         assert request.url.params["fields"] == MATTER_FIELDS
+        assert "status" not in request.url.params
+
+    @respx.mock
+    async def test_passes_status_filter(self, client: ClioClient) -> None:
+        route = respx.get("https://app.clio.com/api/v4/matters.json").mock(
+            return_value=httpx.Response(200, json={"data": [MATTER_PAYLOAD]})
+        )
+
+        await client.search_matters("Smith", limit=10, status="open")
+
+        request = route.calls[0].request
+        assert request.url.params["status"] == "open"
 
     @respx.mock
     async def test_parses_nested_refs_from_expanded_payload(

--- a/tests/test_tools/test_matters.py
+++ b/tests/test_tools/test_matters.py
@@ -37,8 +37,18 @@ async def test_search_matters_delegates_to_client(sample_matter: Matter) -> None
     with patch.object(matters, "_get_client", return_value=fake_client):
         result = await matters.search_matters("Smith", limit=10)
 
-    fake_client.search_matters.assert_awaited_once_with("Smith", 10)
+    fake_client.search_matters.assert_awaited_once_with("Smith", 10, None)
     assert result == [sample_matter]
+
+
+async def test_search_matters_passes_status(sample_matter: Matter) -> None:
+    fake_client = AsyncMock()
+    fake_client.search_matters.return_value = [sample_matter]
+
+    with patch.object(matters, "_get_client", return_value=fake_client):
+        await matters.search_matters("Smith", limit=10, status="open")
+
+    fake_client.search_matters.assert_awaited_once_with("Smith", 10, "open")
 
 
 async def test_search_matters_rejects_limit_above_100() -> None:


### PR DESCRIPTION
## Summary

- Adds an optional `status: Literal["open", "pending", "closed"]` param to `search_matters` (tool + `ClioClient`), threaded through to Clio's native `matters.json?status=` filter. Omitted means all statuses; we do not send `status=` when the caller passes `None`.
- Closes the post-hoc-filtering observation from yesterday's Q1 dogfooding ("what matters do I have open for [client]"): the LLM was filtering on `status` from the response because the tool didn't expose Clio's native filter. With this surface change the filter happens server-side.
- Tool docstring gets one sentence on what `status` does and a note that omitting it returns matters of all statuses — no example values, to avoid leaking exact-match expectations into agent behavior.
- No eval case added in this PR. A "show me my open matters" case is the natural follow-up but it's a trajectory-style test and deserves its own thinking.

## Test plan

- [x] `uv run pytest` — 90 passed
- [x] `uv run --group evals python -m evals.harness` — existing 4 cases still 4/4 PASS (none pass `status`, so behavior is unchanged for them)
- [x] New client test asserts `status=open` is sent when passed, and `status` is NOT in params when omitted (the negative assertion guards against silently sending `status=None` as a string)