### PR TITLE
feat(observability): add custom OTel attributes on tool spans

### DIFF
--- a/src/clio_mcp/observability.py
+++ b/src/clio_mcp/observability.py
@@ -3,15 +3,72 @@
 OTel is optional: if the `otel` dependency group is not installed, this
 module logs a single warning to stderr and returns. Spans are exported
 over OTLP/gRPC; never to stdout, which is the MCP protocol channel.
+
+This module also re-exports `trace`, `Status`, and `StatusCode` from
+opentelemetry so tool modules can acquire a tracer with a single import.
+If OTel is not installed, no-op stand-ins are exported instead so tool
+modules remain importable.
 """
 
 from __future__ import annotations
 
 import sys
+from typing import Any
 
 _SERVICE_NAME = "clio-mcp-server"
 
 _configured = False
+
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.trace import Status, StatusCode
+except ImportError:
+
+    class _NoOpSpan:
+        def __enter__(self) -> _NoOpSpan:
+            return self
+
+        def __exit__(self, *exc_info: object) -> bool:
+            return False
+
+        def set_attribute(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def set_status(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        def record_exception(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+    class _NoOpTracer:
+        def start_as_current_span(
+            self, name: str, *args: Any, **kwargs: Any
+        ) -> _NoOpSpan:
+            return _NoOpSpan()
+
+    class _NoOpTraceModule:
+        @staticmethod
+        def get_tracer(name: str) -> _NoOpTracer:
+            return _NoOpTracer()
+
+        @staticmethod
+        def set_tracer_provider(provider: object) -> None:
+            pass
+
+    trace = _NoOpTraceModule()  # type: ignore[assignment]
+
+    class StatusCode:  # type: ignore[no-redef]
+        ERROR = "ERROR"
+        OK = "OK"
+        UNSET = "UNSET"
+
+    class Status:  # type: ignore[no-redef]
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            pass
+
+
+__all__ = ["Status", "StatusCode", "setup_tracing", "trace"]
 
 
 def setup_tracing() -> None:

--- a/src/clio_mcp/tools/contacts.py
+++ b/src/clio_mcp/tools/contacts.py
@@ -7,6 +7,9 @@ from typing import Literal
 from clio_mcp.auth.models import ClioConfig
 from clio_mcp.client import ClioClient
 from clio_mcp.models import Contact
+from clio_mcp.observability import Status, StatusCode, trace
+
+tracer = trace.get_tracer(__name__)
 
 _client: ClioClient | None = None
 
@@ -25,7 +28,22 @@ async def get_contact(contact_id: int) -> Contact:
     and need its details; use search_contacts instead if you're looking
     for contacts by name or keyword.
     """
-    return await _get_client().get_contact(contact_id)
+    with tracer.start_as_current_span(
+        "tool.get_contact",
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        span.set_attribute("clio.tool.name", "get_contact")
+        span.set_attribute("clio.tool.args_keys", "contact_id")
+        try:
+            result = await _get_client().get_contact(contact_id)
+        except Exception as exc:
+            span.set_attribute("clio.tool.result.shape", "error")
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise
+        span.set_attribute("clio.tool.result.shape", "dict")
+        return result
 
 
 async def search_contacts(
@@ -50,6 +68,25 @@ async def search_contacts(
     Returns up to limit contacts (default 25, max 100). Passing a limit
     above 100 raises ValueError.
     """
-    if limit > 100:
-        raise ValueError("limit must be 100 or fewer")
-    return await _get_client().search_contacts(query, type, limit)
+    args_keys = ["limit", "query"]
+    if type is not None:
+        args_keys.append("type")
+    with tracer.start_as_current_span(
+        "tool.search_contacts",
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        span.set_attribute("clio.tool.name", "search_contacts")
+        span.set_attribute("clio.tool.args_keys", ",".join(args_keys))
+        try:
+            if limit > 100:
+                raise ValueError("limit must be 100 or fewer")
+            result = await _get_client().search_contacts(query, type, limit)
+        except Exception as exc:
+            span.set_attribute("clio.tool.result.shape", "error")
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise
+        span.set_attribute("clio.tool.result.shape", "list")
+        span.set_attribute("clio.tool.result.item_count", len(result))
+        return result

--- a/src/clio_mcp/tools/matters.py
+++ b/src/clio_mcp/tools/matters.py
@@ -7,6 +7,9 @@ from typing import Literal
 from clio_mcp.auth.models import ClioConfig
 from clio_mcp.client import ClioClient
 from clio_mcp.models import Matter
+from clio_mcp.observability import Status, StatusCode, trace
+
+tracer = trace.get_tracer(__name__)
 
 _client: ClioClient | None = None
 
@@ -25,7 +28,22 @@ async def get_matter(matter_id: int) -> Matter:
     search_matters instead if you're looking for matters by name,
     client, or keyword.
     """
-    return await _get_client().get_matter(matter_id)
+    with tracer.start_as_current_span(
+        "tool.get_matter",
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        span.set_attribute("clio.tool.name", "get_matter")
+        span.set_attribute("clio.tool.args_keys", "matter_id")
+        try:
+            result = await _get_client().get_matter(matter_id)
+        except Exception as exc:
+            span.set_attribute("clio.tool.result.shape", "error")
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise
+        span.set_attribute("clio.tool.result.shape", "dict")
+        return result
 
 
 async def search_matters(
@@ -48,6 +66,25 @@ async def search_matters(
     Returns up to limit matters (default 25, max 100). Passing a limit
     above 100 raises ValueError.
     """
-    if limit > 100:
-        raise ValueError("limit must be 100 or fewer")
-    return await _get_client().search_matters(query, limit, status)
+    args_keys = ["limit", "query"]
+    if status is not None:
+        args_keys.append("status")
+    with tracer.start_as_current_span(
+        "tool.search_matters",
+        record_exception=False,
+        set_status_on_exception=False,
+    ) as span:
+        span.set_attribute("clio.tool.name", "search_matters")
+        span.set_attribute("clio.tool.args_keys", ",".join(args_keys))
+        try:
+            if limit > 100:
+                raise ValueError("limit must be 100 or fewer")
+            result = await _get_client().search_matters(query, limit, status)
+        except Exception as exc:
+            span.set_attribute("clio.tool.result.shape", "error")
+            span.record_exception(exc)
+            span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise
+        span.set_attribute("clio.tool.result.shape", "list")
+        span.set_attribute("clio.tool.result.item_count", len(result))
+        return result

--- a/tests/test_tool_spans.py
+++ b/tests/test_tool_spans.py
@@ -1,0 +1,132 @@
+"""Tests for the custom OTel spans emitted by tool handlers.
+
+Asserts the per-tool span name, the clio.tool.* attribute schema, and
+the error-path behavior (status=ERROR + recorded exception event).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from opentelemetry import trace
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import (
+    InMemorySpanExporter,
+)
+from opentelemetry.trace import StatusCode
+
+from clio_mcp.models import ContactPerson, Matter
+from clio_mcp.tools import contacts, matters
+
+
+@pytest.fixture(scope="module")
+def _tracer_provider() -> InMemorySpanExporter:
+    """Install a global TracerProvider that captures spans in memory.
+
+    OTel disallows fully replacing a provider once set, so this is
+    module-scoped and the per-test fixture clears the exporter between
+    runs.
+    """
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+    return exporter
+
+
+@pytest.fixture
+def span_exporter(
+    _tracer_provider: InMemorySpanExporter,
+) -> Iterator[InMemorySpanExporter]:
+    _tracer_provider.clear()
+    yield _tracer_provider
+    _tracer_provider.clear()
+
+
+def _only_tool_span(exporter: InMemorySpanExporter) -> ReadableSpan:
+    spans = [s for s in exporter.get_finished_spans() if s.name.startswith("tool.")]
+    assert len(spans) == 1, f"expected exactly one tool span, got {len(spans)}"
+    return spans[0]
+
+
+async def test_get_matter_emits_dict_shape_span(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    sample = Matter(id=1, display_number="00001-Smith")
+    fake_client = AsyncMock()
+    fake_client.get_matter.return_value = sample
+
+    with patch.object(matters, "_get_client", return_value=fake_client):
+        await matters.get_matter(1)
+
+    span = _only_tool_span(span_exporter)
+    assert span.name == "tool.get_matter"
+    assert span.attributes is not None
+    assert span.attributes["clio.tool.name"] == "get_matter"
+    assert span.attributes["clio.tool.args_keys"] == "matter_id"
+    assert span.attributes["clio.tool.result.shape"] == "dict"
+    assert "clio.tool.result.item_count" not in span.attributes
+    assert span.status.status_code != StatusCode.ERROR
+
+
+async def test_search_contacts_emits_list_shape_span_with_count(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    fake_client = AsyncMock()
+    fake_client.search_contacts.return_value = [
+        ContactPerson(id=1, type="Person", first_name="Jane", last_name="Smith"),
+        ContactPerson(id=2, type="Person", first_name="John", last_name="Smith"),
+    ]
+
+    with patch.object(contacts, "_get_client", return_value=fake_client):
+        await contacts.search_contacts("Smith", type="Person", limit=10)
+
+    span = _only_tool_span(span_exporter)
+    assert span.name == "tool.search_contacts"
+    assert span.attributes is not None
+    assert span.attributes["clio.tool.name"] == "search_contacts"
+    # Comma-separated, sorted, includes 'type' because it was provided.
+    assert span.attributes["clio.tool.args_keys"] == "limit,query,type"
+    assert span.attributes["clio.tool.result.shape"] == "list"
+    assert span.attributes["clio.tool.result.item_count"] == 2
+
+
+async def test_search_matters_omits_optional_arg_key_when_absent(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    fake_client = AsyncMock()
+    fake_client.search_matters.return_value = []
+
+    with patch.object(matters, "_get_client", return_value=fake_client):
+        await matters.search_matters("Smith", limit=5)
+
+    span = _only_tool_span(span_exporter)
+    assert span.attributes is not None
+    assert span.attributes["clio.tool.args_keys"] == "limit,query"
+    assert span.attributes["clio.tool.result.item_count"] == 0
+
+
+async def test_tool_span_records_exception_and_sets_error_status(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    fake_client = AsyncMock()
+    fake_client.get_matter.side_effect = RuntimeError("clio exploded")
+
+    with (
+        patch.object(matters, "_get_client", return_value=fake_client),
+        pytest.raises(RuntimeError, match="clio exploded"),
+    ):
+        await matters.get_matter(42)
+
+    span = _only_tool_span(span_exporter)
+    assert span.name == "tool.get_matter"
+    assert span.status.status_code == StatusCode.ERROR
+    assert span.attributes is not None
+    assert span.attributes["clio.tool.result.shape"] == "error"
+    assert "clio.tool.result.item_count" not in span.attributes
+
+    exception_events = [e for e in span.events if e.name == "exception"]
+    assert len(exception_events) == 1


### PR DESCRIPTION
Each tool handler now opens a tool.{name} span between the FastMCP tools/call span and the httpx GET span, with attributes: clio.tool.name, clio.tool.args_keys (keys only — values are confidential), clio.tool.result.shape (dict|list|error), and clio.tool.result.item_count when the result is a list. Errors set shape=error, record the exception event, and mark the span ERROR.

observability re-exports trace, Status, and StatusCode with no-op fallbacks so tool modules remain importable when the otel dependency group is absent.