### PR TITLE
chore(precommit): add ruff hook to mirror CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,13 @@ repos:
         always_run: true
         stages: [pre-commit]
 
+      - id: ruff
+        name: ruff check (uv run ruff)
+        entry: uv run ruff check .
+        language: system
+        pass_filenames: false
+        stages: [pre-commit]
+
       - id: block-client-names
         name: Block client names from denylist
         entry: scripts/check_client_names.py


### PR DESCRIPTION
Adds ruff as a pre-commit hook so violations get caught locally before
hitting CI, mirroring what CI already runs (uv run ruff check .).

Motivation: PR #30's CI run caught three B905 violations that local
pytest didn't surface, because pre-commit was running pytest, gitleaks,
block-client-names, and conventional-commit but not ruff. This closes
that gap.

Hook follows the existing local-hook pattern (language: system, entry
via uv run) so the ruff version matches the project's pinned dev
dependency rather than drifting via pre-commit autoupdate.

Ran ruff against the full repo before adding — no existing violations,
so the hook lands clean.