### PR TITLE
fix(matters): make query optional in search_matters

### DIFF
--- a/src/clio_mcp/client.py
+++ b/src/clio_mcp/client.py
@@ -64,15 +64,16 @@ class ClioClient:
 
     async def search_matters(
         self,
-        query: str,
+        query: str | None = None,
         limit: int = 25,
         status: Literal["open", "pending", "closed"] | None = None,
     ) -> list[Matter]:
         params: dict[str, Any] = {
-            "query": query,
             "limit": limit,
             "fields": MATTER_FIELDS,
         }
+        if query is not None:
+            params["query"] = query
         if status is not None:
             params["status"] = status
         payload = await self._request("GET", "/matters.json", params=params)

--- a/src/clio_mcp/tools/matters.py
+++ b/src/clio_mcp/tools/matters.py
@@ -51,20 +51,26 @@ async def search_matters(
     limit: int = 25,
     status: Literal["open", "pending", "closed"] | None = None,
 ) -> list[Matter]:
-    """Search for matters by keyword. Matches against matter numbers,
-    descriptions, and client names.
+    """List matters, optionally filtered by keyword and/or status.
+    Both filters are optional — call with neither to list recent
+    matters across all statuses, with either to narrow on one
+    dimension, or with both to combine.
 
-    Pass distinctive terms — a company name, person's last name.
-    Do not pass full sentences or predicate expressions.
+    query is a keyword search against matter numbers, descriptions,
+    and client names. Pass distinctive terms — a company name, a
+    person's last name. Do not pass full sentences or predicate
+    expressions. Omit query when the user has not named a specific
+    matter or party.
 
     Good: "Acme", "Smith"
     Bad: "all Smith matters", "client name contains Acme"
 
-    The optional status filter restricts results to matters in that
-    status; omit it to return matters of all statuses.
+    status restricts results to matters in that status ("open",
+    "pending", or "closed"). Omit it to return matters of all
+    statuses.
 
-    Returns up to limit matters (default 25, max 100). Passing a limit
-    above 100 raises ValueError.
+    Returns up to limit matters (default 25, max 100). Passing a
+    limit above 100 raises ValueError.
     """
     args_keys = ["limit"]
     if query is not None:

--- a/src/clio_mcp/tools/matters.py
+++ b/src/clio_mcp/tools/matters.py
@@ -47,7 +47,7 @@ async def get_matter(matter_id: int) -> Matter:
 
 
 async def search_matters(
-    query: str,
+    query: str | None = None,
     limit: int = 25,
     status: Literal["open", "pending", "closed"] | None = None,
 ) -> list[Matter]:
@@ -66,7 +66,9 @@ async def search_matters(
     Returns up to limit matters (default 25, max 100). Passing a limit
     above 100 raises ValueError.
     """
-    args_keys = ["limit", "query"]
+    args_keys = ["limit"]
+    if query is not None:
+        args_keys.append("query")
     if status is not None:
         args_keys.append("status")
     with tracer.start_as_current_span(

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -165,6 +165,21 @@ class TestSearchMatters:
         assert request.url.params["status"] == "open"
 
     @respx.mock
+    async def test_omits_query_param_when_query_is_none(
+        self, client: ClioClient
+    ) -> None:
+        route = respx.get("https://app.clio.com/api/v4/matters.json").mock(
+            return_value=httpx.Response(200, json={"data": [MATTER_PAYLOAD]})
+        )
+
+        await client.search_matters(limit=10, status="open")
+
+        request = route.calls[0].request
+        assert "query" not in request.url.params
+        assert request.url.params["limit"] == "10"
+        assert request.url.params["status"] == "open"
+
+    @respx.mock
     async def test_parses_nested_refs_from_expanded_payload(
         self, client: ClioClient
     ) -> None:

--- a/tests/test_tool_spans.py
+++ b/tests/test_tool_spans.py
@@ -109,6 +109,20 @@ async def test_search_matters_omits_optional_arg_key_when_absent(
     assert span.attributes["clio.tool.result.item_count"] == 0
 
 
+async def test_search_matters_args_keys_omits_query_when_none(
+    span_exporter: InMemorySpanExporter,
+) -> None:
+    fake_client = AsyncMock()
+    fake_client.search_matters.return_value = []
+
+    with patch.object(matters, "_get_client", return_value=fake_client):
+        await matters.search_matters(limit=5, status="open")
+
+    span = _only_tool_span(span_exporter)
+    assert span.attributes is not None
+    assert span.attributes["clio.tool.args_keys"] == "limit,status"
+
+
 async def test_tool_span_records_exception_and_sets_error_status(
     span_exporter: InMemorySpanExporter,
 ) -> None:

--- a/tests/test_tools/test_matters.py
+++ b/tests/test_tools/test_matters.py
@@ -51,6 +51,18 @@ async def test_search_matters_passes_status(sample_matter: Matter) -> None:
     fake_client.search_matters.assert_awaited_once_with("Smith", 10, "open")
 
 
+async def test_search_matters_passes_none_query_when_omitted(
+    sample_matter: Matter,
+) -> None:
+    fake_client = AsyncMock()
+    fake_client.search_matters.return_value = [sample_matter]
+
+    with patch.object(matters, "_get_client", return_value=fake_client):
+        await matters.search_matters(limit=10, status="open")
+
+    fake_client.search_matters.assert_awaited_once_with(None, 10, "open")
+
+
 async def test_search_matters_rejects_limit_above_100() -> None:
     with pytest.raises(ValueError, match="100"):
         await matters.search_matters("Smith", limit=101)


### PR DESCRIPTION
Closes the search_matters_status_filter flakiness flagged in PR #30's
follow-up. The agent was sometimes calling search_matters with
query="*" then retrying without it, producing 2-call trajectories
when 1-call was expected. Root cause: query was required at both the
tool and client layers, so the agent had to invent a value when the
user prompt didn't suggest a keyword.

Commits:
- 1e86e07  fix(matters): make query optional in search_matters tool and client
- 16e3c2a  docs(matters): rewrite search_matters docstring to reflect optional query

Pytest: 101 passing. Eval suite: 6/6 PASS across all five columns,
stable across 3 consecutive runs. The previously-flaky
search_matters_status_filter case is now consistently 1-call.

Eval coverage for the new optional-query path is added in a separate
PR per the cross-modify rule (src/tests vs evals).

Follow-ups:
- search_contacts has the same required-query shape; same fix in a
  separate PR referencing this one.
- Observed one DONE-column flake in run 2 (max_tokens hit during the
  agent's post-tool summary on a 25-matter response). Independent of
  the data-plane fix in this PR. Worth refining what `completed`
  measures in the harness — the data plane was correct, only the
  final-text rendering wobbled. Will file separately.