### PR TITLE
test(evals): add search_matters_no_query case

### DIFF
--- a/evals/cases.py
+++ b/evals/cases.py
@@ -108,6 +108,17 @@ CASES: list[TestCase] = [
         ],
     ),
     TestCase(
+        name="search_matters_no_query",
+        query="List my recent matters.",
+        expected_calls=[
+            ExpectedCall(
+                tool="search_matters",
+                args_subset={},
+                non_null_fields=[],
+            ),
+        ],
+    ),
+    TestCase(
         name="matter_to_client_drilldown",
         query="What's the full contact info for the client on matter id 1668402907?",
         expected_calls=[


### PR DESCRIPTION
Adds eval coverage for the optional-query path introduced in #32.

The case "List my recent matters." routes to search_matters with
empty args (no query, no status), validating that the agent calls
the tool natively without inventing a query value when the user
prompt doesn't suggest one.

Stable across 3 consecutive runs in #32's verification step.